### PR TITLE
Add soft-delete restore/purge, hard-delete + cleanup, user update validation and UI fixes

### DIFF
--- a/api/users/update.php
+++ b/api/users/update.php
@@ -13,6 +13,24 @@ $found = false;
 foreach ($users as &$u) {
   if ($u['id'] === $id) {
     $found = true;
+
+    $newUserid = array_key_exists('userid', $in) ? trim((string)$in['userid']) : (string)($u['userid'] ?? '');
+    $newEmail = array_key_exists('email', $in) ? trim((string)$in['email']) : (string)($u['email'] ?? '');
+    $newDept = array_key_exists('department', $in) ? trim((string)$in['department']) : (string)($u['department'] ?? '');
+
+    foreach ($users as $other) {
+      if (($other['id'] ?? '') === $id) continue;
+      if (strcasecmp((string)($other['userid'] ?? ''), $newUserid) === 0 || strcasecmp((string)($other['email'] ?? ''), $newEmail) === 0) {
+        json_err('UserID oder E-Mail bereits vergeben', 409);
+      }
+    }
+
+    $settings = load_app_settings();
+    $departments = $settings['departments'] ?? [];
+    if ($newDept !== '' && !in_array($newDept, $departments, true)) {
+      json_err('Ungültige Abteilung', 422);
+    }
+
     foreach (['first_name','last_name','userid','email','role','locked', 'department'] as $k) {
       if (array_key_exists($k, $in)) {
         if ($k==='role' && !in_array($in[$k], ['user','admin'], true)) continue;

--- a/app/app.js
+++ b/app/app.js
@@ -82,10 +82,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (el) el.textContent = AuthManager.username() || 'Unbekannt';
 
     // Name + Department im Block
-    document.getElementById('me-userdata').innerHTML = `
-      <strong>Name:</strong> ${AuthManager.username()}<br>
-      <strong>Abteilung:</strong> ${AuthManager.department() || '—'}
-    `;
+            const userDataEl = document.getElementById('me-userdata');
+            if (userDataEl) {
+                userDataEl.replaceChildren(
+                    Object.assign(document.createElement('strong'), { textContent: 'Name:' }),
+                    document.createTextNode(` ${AuthManager.username() || 'Unbekannt'}`),
+                    document.createElement('br'),
+                    Object.assign(document.createElement('strong'), { textContent: 'Abteilung:' }),
+                    document.createTextNode(` ${AuthManager.department() || '—'}`)
+                );
+            }
             if (AuthManager.isAdmin()) {
                     document.getElementById('admin-menu')?.classList.remove('d-none');
                 }
@@ -214,6 +220,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('add-h3').addEventListener('click', () => ItemManager.addItem('h3'));
     document.getElementById('add-p').addEventListener('click', () => ItemManager.addItem('p'));
 
+    document.getElementById('restore-deleted-items')?.addEventListener('click', () => {
+        ItemManager.restoreDeletedItems();
+    });
+
+    document.getElementById('purge-deleted-items')?.addEventListener('click', () => {
+        const currentList = StateManager.getCurrentList();
+        if (!currentList) return;
+
+        const deletedCount = ItemManager.countSoftDeletedItems(currentList.items || []);
+        if (deletedCount === 0) {
+            UIManager.showToast('Keine gelöschten Elemente vorhanden', 'info');
+            return;
+        }
+
+        if (confirm(`${deletedCount} gelöschte Elemente endgültig löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.`)) {
+            ItemManager.hardDeleteAllSoftDeletedItems();
+        }
+    });
+
 
     document.getElementById('showGantt').addEventListener('click', () => GanttManager.showGantt());
 
@@ -232,28 +257,29 @@ document.addEventListener('DOMContentLoaded', async () => {
  
 const switchEl2 = document.getElementById('planModeSwitch');
 
-switchEl2.addEventListener('change', (e) => {
-  if (e.target.checked) {
-    PlanModeManager.enable();
-  } else {
-    // disable startet einen Dialog
-    PlanModeManager.disable();
+if (switchEl2) {
+    switchEl2.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        PlanModeManager.enable();
+      } else {
+        // disable startet einen Dialog
+        PlanModeManager.disable();
 
-    // Wenn das Modal einfach geschlossen wird (X oder ESC),
-    // bleibt der Planmodus aktiv → Switch wieder aktivieren
-    const modalEl = document.getElementById('mainModal');
-    const bootstrapModal = bootstrap.Modal.getInstance(modalEl);
+        // Wenn das Modal einfach geschlossen wird (X oder ESC),
+        // bleibt der Planmodus aktiv → Switch wieder aktivieren
+        const modalEl = document.getElementById('mainModal');
 
-    if (modalEl) {
-      modalEl.addEventListener('hidden.bs.modal', () => {
-        if (StateManager.isPlanModeActive()) {
-          // Nutzer hat abgebrochen
-          switchEl2.checked = true;
+        if (modalEl) {
+          modalEl.addEventListener('hidden.bs.modal', () => {
+            if (StateManager.isPlanModeActive()) {
+              // Nutzer hat abgebrochen
+              switchEl2.checked = true;
+            }
+          }, { once: true });
         }
-      }, { once: true });
+      }
+    });
     }
-  }
-});
 
 
 

--- a/app/index.html
+++ b/app/index.html
@@ -337,6 +337,14 @@
                 <button id="add-p" data-editable="true" class="btn btn-sm btn-outline-secondary">
                     <i class="bi bi-text-paragraph"></i> Punkt
                 </button>
+
+                <button id="restore-deleted-items" class="btn btn-sm btn-outline-info ms-2" title="Soft-gelöschte Einträge wiederherstellen">
+                    <i class="bi bi-arrow-counterclockwise"></i> Wiederherstellen
+                </button>
+
+                <button id="purge-deleted-items" class="btn btn-sm btn-outline-danger" title="Soft-gelöschte Einträge endgültig löschen">
+                    <i class="bi bi-trash3"></i> Endgültig löschen
+                </button>
                 
                 </div>
             </div>

--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -172,6 +172,152 @@ export const ItemManager = {
         
         UIManager.removeItemFromUI(itemId);
     },
+
+    restoreDeletedItems() {
+        const restoredIds = [];
+
+        const restoreRecursive = (items) => {
+            items.forEach(item => {
+                if (item.isDeleted) {
+                    item.isDeleted = false;
+                    restoredIds.push(item.id);
+                }
+                if (item.children?.length) restoreRecursive(item.children);
+            });
+        };
+
+        StateManager.updateProject(project => {
+            const currentList = StateManager.getCurrentList();
+            const list = currentList ? project.lists[currentList.meta.id] : null;
+            if (!list) return project;
+
+            restoreRecursive(list.items || []);
+            if (restoredIds.length > 0) {
+                list.meta.lastModified = new Date().toISOString();
+                restoredIds.forEach(id => HistoryManager.logChange(id, 'UPDATE', { reason: 'Wiederhergestellt' }));
+            }
+            return project;
+        });
+
+        if (restoredIds.length > 0) {
+            UIManager.refreshListContent();
+            UIManager.showToast(`${restoredIds.length} Einträge wiederhergestellt`, 'success');
+        }
+    },
+
+    hardDeleteItem(itemId) {
+        const removedIds = [];
+
+        const collectIds = (node) => {
+            if (!node) return;
+            removedIds.push(node.id);
+            (node.children || []).forEach(collectIds);
+        };
+
+        const removeDependencies = (items, idSet) => {
+            items.forEach(it => {
+                if (Array.isArray(it?.data?.dependencies)) {
+                    it.data.dependencies = it.data.dependencies.filter(dep => !idSet.has(dep.id));
+                }
+                if (it.children?.length) removeDependencies(it.children, idSet);
+            });
+        };
+
+        StateManager.updateProject(project => {
+            const currentList = StateManager.getCurrentList();
+            const list = currentList ? project.lists[currentList.meta.id] : null;
+            if (!list) return project;
+
+            const removedSubtree = this.removeItemById(list.items, itemId);
+            if (!removedSubtree) return project;
+
+            collectIds(removedSubtree);
+            const removedSet = new Set(removedIds);
+            removeDependencies(list.items || [], removedSet);
+
+            (removedIds || []).forEach(id => {
+                if (project.changelog?.[id]) delete project.changelog[id];
+            });
+
+            list.meta.lastModified = new Date().toISOString();
+            HistoryManager.logChange(itemId, 'DELETE', { reason: 'ENDGUELTIG_GELOESCHT', count: removedIds.length });
+            return project;
+        });
+
+        if (removedIds.length > 0) {
+            UIManager.refreshListContent();
+            UIManager.showToast(`${removedIds.length} Einträge endgültig gelöscht`, 'success');
+        }
+    },
+
+    hardDeleteAllSoftDeletedItems() {
+        const removedIds = [];
+
+        const purgeRecursive = (items) => {
+            const kept = [];
+            for (const item of items) {
+                if (item.isDeleted) {
+                    const stack = [item];
+                    while (stack.length) {
+                        const cur = stack.pop();
+                        removedIds.push(cur.id);
+                        (cur.children || []).forEach(c => stack.push(c));
+                    }
+                    continue;
+                }
+                if (item.children?.length) item.children = purgeRecursive(item.children);
+                kept.push(item);
+            }
+            return kept;
+        };
+
+        const removeDependencies = (items, idSet) => {
+            items.forEach(it => {
+                if (Array.isArray(it?.data?.dependencies)) {
+                    it.data.dependencies = it.data.dependencies.filter(dep => !idSet.has(dep.id));
+                }
+                if (it.children?.length) removeDependencies(it.children, idSet);
+            });
+        };
+
+        StateManager.updateProject(project => {
+            const currentList = StateManager.getCurrentList();
+            const list = currentList ? project.lists[currentList.meta.id] : null;
+            if (!list) return project;
+
+            list.items = purgeRecursive(list.items || []);
+
+            if (removedIds.length > 0) {
+                const removedSet = new Set(removedIds);
+                removeDependencies(list.items || [], removedSet);
+                removedIds.forEach(id => {
+                    if (project.changelog?.[id]) delete project.changelog[id];
+                });
+                list.meta.lastModified = new Date().toISOString();
+            }
+
+            return project;
+        });
+
+        if (removedIds.length > 0) {
+            UIManager.refreshListContent();
+            UIManager.showToast(`${removedIds.length} Papierkorb-Elemente endgültig gelöscht`, 'success');
+        } else {
+            UIManager.showToast('Keine gelöschten Elemente vorhanden', 'info');
+        }
+    },
+
+    countSoftDeletedItems(items = []) {
+        let count = 0;
+        const visit = (nodes) => {
+            nodes.forEach(node => {
+                if (node.isDeleted) count += 1;
+                if (node.children?.length) visit(node.children);
+            });
+        };
+        visit(items);
+        return count;
+    },
     
     findItemById(items, itemId) {
         for (const item of items) {

--- a/app/listManager.js
+++ b/app/listManager.js
@@ -180,17 +180,43 @@ export const ListManager = {
 	
     deleteList(listId) {
         StateManager.updateProject(project => {
+            const list = project.lists?.[listId];
+
+            const collectItemIds = (items = [], out = []) => {
+                items.forEach(item => {
+                    out.push(item.id);
+                    if (item.children?.length) collectItemIds(item.children, out);
+                });
+                return out;
+            };
+
+            const listItemIds = list ? collectItemIds(list.items || []) : [];
+
             // Aus manifest entfernen
             project.manifest.lists = project.manifest.lists.filter(list => list.id !== listId);
             
             // Aus Listen entfernen
             delete project.lists[listId];
+
+            // Zugehörige Snapshots endgültig löschen
+            if (project.snapshots?.[listId]) {
+                delete project.snapshots[listId];
+            }
+
+            // Zugehörige Changelog-Einträge entfernen
+            listItemIds.forEach(itemId => {
+                if (project.changelog?.[itemId]) delete project.changelog[itemId];
+            });
             
             // Aus finalisierten entfernen
             project.finalizedLists = project.finalizedLists.filter(id => id !== listId);
             
             return project;
         });
+
+        if (StateManager.getCurrentList()?.meta?.id === listId) {
+            StateManager.setCurrentList(null);
+        }
         
         UIManager.updateLists(StateManager.getCurrentProject().lists);
         UIManager.showToast('Liste gelöscht', 'success');


### PR DESCRIPTION
### Motivation

- Provide end-to-end handling for soft-deleted items including restore and permanent purge operations to improve data lifecycle management.
- Prevent inconsistent user records by adding uniqueness checks for `userid` and `email` and validating `department` on user updates.
- Improve UI robustness by avoiding `innerHTML` for user info, wiring new restore/purge buttons, and fixing the plan-mode toggle event handling.

### Description

- Added uniqueness and department validation to the user update endpoint in `api/users/update.php`, returning `409` on duplicate `userid`/`email` and `422` for invalid `department`, and preserved safe field updates and `updated_at` timestamp.
- Implemented soft-deleted item management in `app/itemManager.js` with `restoreDeletedItems`, `hardDeleteItem`, `hardDeleteAllSoftDeletedItems`, and `countSoftDeletedItems`, including dependency cleanup and changelog removal, and updated UI via `UIManager` calls.
- Added UI controls in `app/index.html` for `restore-deleted-items` and `purge-deleted-items` and wired their actions in `app/app.js`, including confirmation for purge, toast feedback, and a safer DOM update for the current user info using `replaceChildren` instead of `innerHTML`.
- Fixed the plan-mode switch setup in `app/app.js` to guard for a missing element and ensure the modal "hidden" handler is attached with `{ once: true }` to avoid duplicate listeners.
- Extended `ListManager.deleteList` in `app/listManager.js` to remove snapshots and changelog entries associated with a deleted list and unset the current list if it was removed.

### Testing

- No automated tests were added or executed as part of this change.
- Manual smoke checks were implied by the UI wiring (restore/purge buttons, plan-mode behavior, and user update validation) but not recorded as automated test results.
- Existing application behavior for list deletion, item deletion, and user updates should be verified by integration tests before production deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57a7ed4988328bd5f65618205a0a7)