### PR TITLE
Erweiterter Modus: selektives Wiederherstellen & endgültiges Löschen

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -258,7 +258,23 @@ switchEl2.addEventListener('change', (e) => {
 
 
 
-    // Drag & Drop Initialisierung
+    
+const advancedSwitch = document.getElementById('advancedModeSwitch');
+if (advancedSwitch) {
+    advancedSwitch.checked = false;
+    StateManager.setAdvancedModeActive(false);
+    advancedSwitch.addEventListener('change', (e) => {
+        StateManager.setAdvancedModeActive(e.target.checked);
+        UIManager.updateLists(StateManager.getCurrentProject()?.lists || {});
+        const currentList = StateManager.getCurrentList();
+        if (currentList?.meta?.id) {
+            UIManager.updateSnapshotsForList(currentList.meta.id);
+        }
+        UIManager.refreshListContent();
+    });
+}
+
+// Drag & Drop Initialisierung
     UIManager.setupDragDropContainers();
 
     // Laden der Vorlagen

--- a/app/commentManager.js
+++ b/app/commentManager.js
@@ -43,10 +43,19 @@ async showCommentModal(itemId) {
     const limit = await SettingsManager.getSetting("commentLimit") ?? 0;
     const categories = await SettingsManager.getSetting("commentCategories") ?? ["Allgemein"];
 
-    const commentsHtml = item.comments.map(c => `
-      <div class="border rounded p-2 mb-2">
-        <div><strong>${c.author}</strong> (${c.category})</div>
-        <div class="text-muted small">${new Date(c.date).toLocaleString()}</div>
+    const advancedMode = StateManager.isAdvancedModeActive();
+    const commentsHtml = item.comments
+      .filter(c => advancedMode || !c.isDeleted)
+      .map(c => `
+      <div class="border rounded p-2 mb-2 ${c.isDeleted ? 'bg-light text-muted border-danger-subtle' : ''}">
+        <div class="d-flex justify-content-between">
+          <div><strong>${c.author}</strong> (${c.category})</div>
+          <div class="btn-group btn-group-sm">
+            ${!c.isDeleted ? `<button class="btn btn-outline-danger comment-delete" data-comment-id="${c.id}">Löschen</button>` : ''}
+            ${advancedMode && c.isDeleted ? `<button class="btn btn-outline-success comment-restore" data-comment-id="${c.id}">Wiederherstellen</button><button class="btn btn-outline-danger comment-delete-permanent" data-comment-id="${c.id}">Endgültig löschen</button>` : ''}
+          </div>
+        </div>
+        <div class="text-muted small">${new Date(c.date).toLocaleString()}${c.isDeleted ? ' · gelöscht' : ''}</div>
         <div>${c.text}</div>
       </div>
     `).join('') || "<p class='text-muted'>Keine Kommentare vorhanden</p>";
@@ -84,6 +93,33 @@ async showCommentModal(itemId) {
       }
     );
 
+    document.querySelectorAll('.comment-delete').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const commentId = btn.dataset.commentId;
+        this.softDeleteComment(itemId, commentId);
+        this.showCommentModal(itemId);
+      });
+    });
+
+    document.querySelectorAll('.comment-restore').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const commentId = btn.dataset.commentId;
+        this.restoreComment(itemId, commentId);
+        this.showCommentModal(itemId);
+      });
+    });
+
+    document.querySelectorAll('.comment-delete-permanent').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const commentId = btn.dataset.commentId;
+        this.deleteCommentPermanently(itemId, commentId);
+        this.showCommentModal(itemId);
+      });
+    });
+
     if (limit > 0) {
       const textarea = document.getElementById("comment-text");
       const counter = document.getElementById("comment-counter");
@@ -115,6 +151,42 @@ async showCommentModal(itemId) {
     list.meta.lastModified = new Date().toISOString();
     UIManager.showToast("Kommentar hinzugefügt", "success");
     return comment;
+  },
+
+  softDeleteComment(itemId, commentId) {
+    const list = StateManager.getCurrentList();
+    if (!list) return;
+    const item = ItemManager.findItemById(list.items, itemId);
+    if (!item || !Array.isArray(item.comments)) return;
+
+    const comment = item.comments.find(c => c.id === commentId);
+    if (!comment) return;
+    comment.isDeleted = true;
+    comment.deletedAt = new Date().toISOString();
+    list.meta.lastModified = new Date().toISOString();
+  },
+
+  restoreComment(itemId, commentId) {
+    const list = StateManager.getCurrentList();
+    if (!list) return;
+    const item = ItemManager.findItemById(list.items, itemId);
+    if (!item || !Array.isArray(item.comments)) return;
+
+    const comment = item.comments.find(c => c.id === commentId);
+    if (!comment) return;
+    comment.isDeleted = false;
+    delete comment.deletedAt;
+    list.meta.lastModified = new Date().toISOString();
+  },
+
+  deleteCommentPermanently(itemId, commentId) {
+    const list = StateManager.getCurrentList();
+    if (!list) return;
+    const item = ItemManager.findItemById(list.items, itemId);
+    if (!item || !Array.isArray(item.comments)) return;
+
+    item.comments = item.comments.filter(c => c.id !== commentId);
+    list.meta.lastModified = new Date().toISOString();
   },
 
   limitText(text) {

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -362,3 +362,9 @@ body.planmode::before {
   font-weight: bold;
   padding: 0.3rem;
 }
+
+.deleted-entry {
+    opacity: 0.65;
+    border-style: dashed !important;
+    filter: grayscale(0.2);
+}

--- a/app/index.html
+++ b/app/index.html
@@ -252,6 +252,12 @@
                                     Planspielmodus
                                 </label>
                             </div>
+                            <div class="form-check form-switch mb-3 pb-3 border-bottom">
+                                <input class="form-check-input" type="checkbox" id="advancedModeSwitch"/>
+                                <label class="form-check-label" for="advancedModeSwitch">
+                                    Erweiterter Modus
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -164,6 +164,7 @@ export const ItemManager = {
             
             if (item) {
                 item.isDeleted = true;
+                item.deletedAt = new Date().toISOString();
                 list.meta.lastModified = new Date().toISOString();
                 HistoryManager.logChange(itemId, 'DELETE', {});
             }
@@ -171,6 +172,59 @@ export const ItemManager = {
         });
         
         UIManager.removeItemFromUI(itemId);
+    },
+    restoreItem(itemId) {
+        StateManager.updateProject(project => {
+            const list = project.lists[StateManager.getCurrentList().meta.id];
+            const item = this.findItemById(list.items, itemId);
+
+            if (item) {
+                item.isDeleted = false;
+                delete item.deletedAt;
+                list.meta.lastModified = new Date().toISOString();
+                HistoryManager.logChange(itemId, 'RESTORE', {});
+            }
+            return project;
+        });
+        UIManager.refreshListContent();
+    },
+
+    deleteItemPermanently(itemId) {
+        StateManager.updateProject(project => {
+            const list = project.lists[StateManager.getCurrentList().meta.id];
+            const removeRec = (items) => {
+                for (let i = items.length - 1; i >= 0; i--) {
+                    const it = items[i];
+                    if (it.id === itemId) {
+                        items.splice(i, 1);
+                        return true;
+                    }
+                    if (Array.isArray(it.children) && it.children.length > 0 && removeRec(it.children)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            const removed = removeRec(list.items);
+            if (removed) {
+                const cleanupDependencies = (items) => {
+                    items.forEach(it => {
+                        if (Array.isArray(it.data?.dependencies)) {
+                            it.data.dependencies = it.data.dependencies.filter(dep => dep.id !== itemId);
+                        }
+                        if (Array.isArray(it.children) && it.children.length > 0) {
+                            cleanupDependencies(it.children);
+                        }
+                    });
+                };
+                cleanupDependencies(list.items);
+                list.meta.lastModified = new Date().toISOString();
+                HistoryManager.logChange(itemId, 'DELETE_PERMANENT', {});
+            }
+            return project;
+        });
+        UIManager.refreshListContent();
     },
     
     findItemById(items, itemId) {

--- a/app/listManager.js
+++ b/app/listManager.js
@@ -178,22 +178,65 @@ export const ListManager = {
     },
     
 	
-    deleteList(listId) {
+    softDeleteList(listId) {
         StateManager.updateProject(project => {
-            // Aus manifest entfernen
-            project.manifest.lists = project.manifest.lists.filter(list => list.id !== listId);
-            
-            // Aus Listen entfernen
-            delete project.lists[listId];
-            
-            // Aus finalisierten entfernen
-            project.finalizedLists = project.finalizedLists.filter(id => id !== listId);
-            
+            const list = project?.lists?.[listId];
+            if (!list) return project;
+
+            list.meta = list.meta || {};
+            list.meta.isDeleted = true;
+            list.meta.deletedAt = new Date().toISOString();
+            list.meta.lastModified = new Date().toISOString();
+
+            const manifestEntry = project?.manifest?.lists?.find(entry => entry.id === listId);
+            if (manifestEntry) {
+                manifestEntry.isDeleted = true;
+                manifestEntry.deletedAt = list.meta.deletedAt;
+            }
+
             return project;
         });
-        
+
         UIManager.updateLists(StateManager.getCurrentProject().lists);
-        UIManager.showToast('Liste gelöscht', 'success');
+        UIManager.showToast('Liste als gelöscht markiert', 'success');
+    },
+
+    restoreList(listId) {
+        StateManager.updateProject(project => {
+            const list = project?.lists?.[listId];
+            if (!list) return project;
+
+            list.meta = list.meta || {};
+            list.meta.isDeleted = false;
+            delete list.meta.deletedAt;
+            list.meta.lastModified = new Date().toISOString();
+
+            const manifestEntry = project?.manifest?.lists?.find(entry => entry.id === listId);
+            if (manifestEntry) {
+                manifestEntry.isDeleted = false;
+                delete manifestEntry.deletedAt;
+            }
+
+            return project;
+        });
+
+        UIManager.updateLists(StateManager.getCurrentProject().lists);
+        UIManager.showToast('Liste wiederhergestellt', 'success');
+    },
+
+    deleteListPermanently(listId) {
+        StateManager.updateProject(project => {
+            project.manifest.lists = (project.manifest.lists || []).filter(list => list.id !== listId);
+            delete project.lists[listId];
+            project.finalizedLists = (project.finalizedLists || []).filter(id => id !== listId);
+            if (project.snapshots) {
+                delete project.snapshots[listId];
+            }
+            return project;
+        });
+
+        UIManager.updateLists(StateManager.getCurrentProject().lists);
+        UIManager.showToast('Liste endgültig gelöscht', 'success');
 
     },
     
@@ -335,7 +378,7 @@ export const ListManager = {
                 const wasCurrent = current && current.meta?.id === deletedId;
 
                 // 1) löschen
-                this.deleteList(deletedId);
+                this.softDeleteList(deletedId);
 
                 // 2) neuen Zustand bestimmen (falls die aktive Liste gelöscht wurde)
                 if (wasCurrent) {

--- a/app/snapshotManager2.js
+++ b/app/snapshotManager2.js
@@ -148,14 +148,39 @@ export const SnapshotManager2 = {
         }
 
         StateManager.updateProject(project => {
-            if (project.snapshots?.[listId]) {
-                project.snapshots[listId] = project.snapshots[listId]
-                    .filter(s => s.id !== snapshotId);
+            const snapshot = project?.snapshots?.[listId]?.find(s => s.id === snapshotId);
+            if (snapshot) {
+                snapshot.isDeleted = true;
+                snapshot.deletedAt = new Date().toISOString();
             }
             return project;
         });
-        
+
         UIManager.removeSnapshotFromUI(snapshotId);
-        UIManager.showToast('Snapshot gelöscht', 'success');
+        UIManager.showToast('Snapshot als gelöscht markiert', 'success');
+    },
+
+    restoreSnapshot(listId, snapshotId) {
+        StateManager.updateProject(project => {
+            const snapshot = project?.snapshots?.[listId]?.find(s => s.id === snapshotId);
+            if (snapshot) {
+                snapshot.isDeleted = false;
+                delete snapshot.deletedAt;
+            }
+            return project;
+        });
+        UIManager.updateSnapshotsForList(listId);
+        UIManager.showToast('Snapshot wiederhergestellt', 'success');
+    },
+
+    deleteSnapshotPermanently(listId, snapshotId) {
+        StateManager.updateProject(project => {
+            if (project.snapshots?.[listId]) {
+                project.snapshots[listId] = project.snapshots[listId].filter(s => s.id !== snapshotId);
+            }
+            return project;
+        });
+        UIManager.updateSnapshotsForList(listId);
+        UIManager.showToast('Snapshot endgültig gelöscht', 'success');
     }
 };

--- a/app/stateManager.js
+++ b/app/stateManager.js
@@ -36,6 +36,7 @@ import { SettingsManager } from './settingsManager.js';
     const state = {
         currentProject: null,
         currentList: null,
+        advancedModeActive: false,
 
         // Planspiel
         planModeActive: false,
@@ -132,6 +133,14 @@ export const StateManager = {
      */
     getCurrentUser() {
         return SettingsManager.getCurrentUser();
+    },
+
+    isAdvancedModeActive() {
+        return !!state.advancedModeActive;
+    },
+
+    setAdvancedModeActive(active) {
+        state.advancedModeActive = !!active;
     },
 
     // --- Planmodus-Handling ---
@@ -251,5 +260,4 @@ _getInternalState() {
         return project;
     }
 };
-
 

--- a/app/uiManager.js
+++ b/app/uiManager.js
@@ -275,7 +275,8 @@ export const UIManager = {
 
         try {
             // Ungültige Einträge herausfiltern
-            const validLists = Object.values(lists).filter(list => list?.meta?.created);
+            const showDeleted = StateManager.isAdvancedModeActive();
+            const validLists = Object.values(lists).filter(list => list?.meta?.created && (showDeleted || !list?.meta?.isDeleted));
             
 
             // Sortieren nach Erstellungsdatum (neueste zuerst)
@@ -316,7 +317,7 @@ export const UIManager = {
 
         const listEl = document.createElement('div');
 		
-        listEl.className = `list-item ${isCurrent ? 'active' : ''} ${isFinalized ? 'finalized' : ''}`;
+        listEl.className = `list-item ${isCurrent ? 'active' : ''} ${isFinalized ? 'finalized' : ''} ${list.meta?.isDeleted ? 'deleted-entry' : ''}`;
 		listEl.dataset.listId = list.meta.id;
 		
         console.log ("Phase:",list.meta.phase)
@@ -326,7 +327,7 @@ export const UIManager = {
 		
 		listEl.innerHTML = `
             <div class="list-item-header">
-                <h5 class="list-title">${list.meta.name}</h5>
+                <h5 class="list-title">${list.meta.name}${list.meta?.isDeleted ? ' <span class="badge text-bg-danger ms-2">gelöscht</span>' : ''}</h5>
                 
             </div>
             <div class="list-item-meta">
@@ -349,6 +350,7 @@ export const UIManager = {
                 <button class="btn btn-sm btn-outline-danger delete-list">
                     <i class="bi bi-trash"></i>
                 </button>
+                ${StateManager.isAdvancedModeActive() && list.meta?.isDeleted ? `<button class="btn btn-sm btn-outline-success restore-list"><i class="bi bi-arrow-counterclockwise"></i></button><button class="btn btn-sm btn-danger delete-list-permanent"><i class="bi bi-trash3"></i></button>` : ""}
             </div>
         `;
 
@@ -365,7 +367,7 @@ export const UIManager = {
 		listEl.querySelector('.delete-list').addEventListener('click', (e) => {
 			e.stopPropagation();
 			if (confirm(`Liste "${list.meta.name}" wirklich löschen?`)) {
-				ListManager.deleteList(list.meta.id);
+				ListManager.softDeleteList(list.meta.id);
 			}
 		});
 
@@ -469,7 +471,7 @@ export const UIManager = {
         const sortedItems = [...items].sort((a, b) => a.sort - b.sort);
         
         sortedItems.forEach(item => {
-            if (item.isDeleted) return;
+            if (item.isDeleted && !StateManager.isAdvancedModeActive()) return;
             
             const itemEl = this.createItemElement(item, level);
 			
@@ -501,7 +503,7 @@ export const UIManager = {
      */
     createItemElement(item, level) {
         const itemEl = document.createElement('div');
-        itemEl.className = `item-card item-${item.type} card`;
+        itemEl.className = `item-card item-${item.type} card ${item.isDeleted ? 'deleted-entry' : ''}`;
         //Filter
         if (item.type === 'p') {
             const status = (item.data.report_status || '').toLowerCase().replace(/\s+/g, '-');
@@ -785,9 +787,10 @@ const commentCount = item.comments?.length || 0;
 						<button class="btn btn-sm btn-outline-primary edit-item">
 							<i class="bi bi-pencil"></i>
 						</button>
-						<button class="btn btn-sm btn-outline-danger delete-item">
-							<i class="bi bi-trash"></i>
-						</button>
+                        ${item.isDeleted && StateManager.isAdvancedModeActive()
+                            ? `<button class="btn btn-sm btn-outline-success restore-item"><i class="bi bi-arrow-counterclockwise"></i></button>
+                               <button class="btn btn-sm btn-danger delete-item-permanent"><i class="bi bi-trash3"></i></button>`
+                            : `<button class="btn btn-sm btn-outline-danger delete-item"><i class="bi bi-trash"></i></button>`}
 						<button class="btn btn-sm btn-outline-secondary history-item" title="Verlauf">
 							<i class="bi bi-clock-history"></i>
 						</button>
@@ -854,10 +857,20 @@ const commentCount = item.comments?.length || 0;
                 HelperManager.showHelpTo("hilfe-itemlist-editor")
             });
             
-            itemEl.querySelector('.delete-item').addEventListener('click', (e) => {
+            itemEl.querySelector('.delete-item')?.addEventListener('click', (e) => {
                 e.stopPropagation();
                 if (confirm(`Item wirklich löschen?`)) {
                 ItemManager.softDeleteItem(item.id);
+                }
+            });
+            itemEl.querySelector('.restore-item')?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                ItemManager.restoreItem(item.id);
+            });
+            itemEl.querySelector('.delete-item-permanent')?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                if (confirm('Item endgültig löschen?')) {
+                    ItemManager.deleteItemPermanently(item.id);
                 }
             });
             itemEl.querySelector('.comment-item').addEventListener('click', (e) => {
@@ -1834,7 +1847,7 @@ const commentCount = item.comments?.length || 0;
     addSnapshotToUI(snapshot) {
 		const container = document.getElementById('snapshots-container');
 		const snapshotEl = document.createElement('div');
-		snapshotEl.className = 'snapshot-card card';
+		snapshotEl.className = `snapshot-card card ${snapshot.isDeleted ? 'deleted-entry' : ''}`;
 		snapshotEl.dataset.snapshotId = snapshot.id;
 		/*snapshotEl.innerHTML = `
 			<div class="card-body">
@@ -1854,11 +1867,12 @@ const commentCount = item.comments?.length || 0;
 <div class="card-body">
 
     <div class="d-flex justify-content-between align-items-center">
-        <h6 class="card-title mb-0">${snapshot.name}</h6>
+        <h6 class="card-title mb-0">${snapshot.name}${snapshot.isDeleted ? " <span class='badge text-bg-danger ms-1'>gelöscht</span>" : ""}</h6>
 
         <button class="btn btn-sm btn-outline-danger delete-snapshot p-1" title="Löschen">
             <i class="bi bi-trash"></i>
         </button>
+        ${StateManager.isAdvancedModeActive() && snapshot.isDeleted ? `<button class="btn btn-sm btn-outline-success restore-snapshot p-1" title="Wiederherstellen"><i class="bi bi-arrow-counterclockwise"></i></button><button class="btn btn-sm btn-danger delete-snapshot-permanent p-1" title="Endgültig löschen"><i class="bi bi-trash3"></i></button>` : ""}
     </div>
 
     <small class="text-muted d-block">${formatDate(snapshot.date)}</small>
@@ -1876,6 +1890,7 @@ const commentCount = item.comments?.length || 0;
 			const listId = StateManager.getCurrentList()?.meta?.id;
 			const allSnapshots = StateManager.getCurrentProject()?.snapshots?.[listId] || [];
 			const snapshotData = allSnapshots.find(s => s.id === snapshot.id);
+			if (snapshotData?.isDeleted) return;
 			if (!snapshotData) return;
 
 			SnapshotManager2.loadSnapshot(snapshotData);
@@ -1888,6 +1903,20 @@ const commentCount = item.comments?.length || 0;
 				SnapshotManager2.deleteSnapshot(listId, snapshot.id);
 			}
 		});
+
+        snapshotEl.querySelector('.restore-snapshot')?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const listId = StateManager.getCurrentList()?.meta?.id;
+            if (listId) SnapshotManager2.restoreSnapshot(listId, snapshot.id);
+        });
+
+        snapshotEl.querySelector('.delete-snapshot-permanent')?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const listId = StateManager.getCurrentList()?.meta?.id;
+            if (listId && confirm('Snapshot endgültig löschen?')) {
+                SnapshotManager2.deleteSnapshotPermanently(listId, snapshot.id);
+            }
+        });
 
 		container.appendChild(snapshotEl);
 	},
@@ -1910,7 +1939,9 @@ const commentCount = item.comments?.length || 0;
 
 
 		//const snapshots = project?.snapshots?.[listId] || [];
+        const showDeleted = StateManager.isAdvancedModeActive();
         const snapshots = [...(project?.snapshots?.[listId] || [])]
+        .filter(s => showDeleted || !s.isDeleted)
         .sort((a, b) => b.date > a.date ? 1 : -1);
 
 		snapshots.forEach(snapshot => {


### PR DESCRIPTION
### Motivation
- Ermöglichen, gelöschte Listen, Snapshots, Items und Kommentare selektiv im UI anzuzeigen und vom Benutzer wiederherstellen oder endgültig löschen zu lassen.
- Verhindern, dass Löschaktionen permanent und irreversibel sind, indem zunächst ein Soft-Delete eingeführt wird und ein spezieller "Erweiterter Modus" diese Einträge sichtbar macht.

### Description
- Neuer Toggle `Erweiterter Modus` in `app/index.html` und zentrale State-Flags `advancedModeActive` mit `isAdvancedModeActive` / `setAdvancedModeActive` im `StateManager` sowie Wiring in `app/app.js` zum Re-Rendern von Listen, Snapshots und Items bei Moduswechsel.
- Listen: `softDeleteList`, `restoreList` und `deleteListPermanently` in `app/listManager.js` eingeführt und Standard-Löschpfade auf Soft-Delete umgestellt; Manifest-Flags und Snapshot-Cleanup berücksichtigt.
- Items: Soft-Delete (`softDeleteItem`), Restore (`restoreItem`) und endgültiges Löschen (`deleteItemPermanently`) in `app/itemManager.js` implementiert; endgültiges Löschen entfernt rekursiv Item und bereinigt `dependencies` anderer Items.
- Snapshots: Soft-Delete, Restore und endgültiges Löschen in `app/snapshotManager2.js` ergänzt, UI-Integration über `UIManager` erlaubt Wiederherstellung/Endgültig-Löschen nur im erweiterten Modus.
- Kommentare: Soft-Delete/Restore/Hard-Delete in `app/commentManager.js` ergänzt und Buttons im Kommentar-Modal für den erweiterten Modus eingebaut.
- UI: `app/uiManager.js` blendet gelöschte Einträge standardmäßig aus, zeigt sie im erweiterten Modus an (visuelle Kennzeichnung via `.deleted-entry`) und stellt Kontext-Buttons (Wiederherstellen / Endgültig löschen) bereit; CSS `.deleted-entry` ergänzt.

### Testing
- JavaScript-Syntax-Checks mit `node --check` für die modifizierten Dateien wurden erfolgreich durchgeführt (keine Fehler gefunden).
- Lokaler PHP-Server (`php -S`) wurde kurz gestartet und eine browsergestützte Screenshotprüfung via Playwright durchgeführt, um die neue Switch-UI sichtbar zu machen (Screenshot erstellt successfully).
- Änderungen wurden in einem Commit zusammengefasst und der PR-Text erzeugt; alle automatisierten Prüfungen in dieser Umgebung liefen ohne Fehler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58526d79483288992d90a2a0bb799)