### PR TITLE
Headline-Ebenen aus Hierarchie ableiten und Drag-&-Drop-Regeln lockern

### DIFF
--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -300,9 +300,9 @@ export const ItemManager = {
 
 		// 3) Level-Regeln (anpassbar)
 		const allowParent = {
-			h1: [null, 'h1', 'h2', 'h3'],
-			h2: [null, 'h1', 'h2', 'h3'],
-			h3: [null, 'h1', 'h2', 'h3'],
+			h1: [null, 'h1', 'h2'],
+			h2: [null, 'h1', 'h2'],
+			h3: [null, 'h1', 'h2'],
 			p: ['h1', 'h2', 'h3'],
 		};
 

--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -288,15 +288,19 @@ export const ItemManager = {
     },
 
 	// Verbindliche Signatur: Objekte rein, nicht IDs
-	isValidDrop(sourceItem, targetItem, position) {
+	getDropValidationResult(sourceItem, targetItem, position) {
 		const list = StateManager.getCurrentList();
-		if (!list || !sourceItem) return false;
+		if (!list || !sourceItem) return { valid: false, reason: 'unbekannt' };
 
 		// 1) Kein Drop in eigene Nachfahren
-		if (targetItem && this.isChildOf(sourceItem, targetItem)) return false;
+		if (targetItem && this.isChildOf(sourceItem, targetItem)) {
+			return { valid: false, reason: 'cycle' };
+		}
 
 		// 2) Niemals "into" in ein p-Element
-		if (position === 'into' && targetItem && targetItem.type === 'p') return false;
+		if (position === 'into' && targetItem && targetItem.type === 'p') {
+			return { valid: false, reason: 'into-paragraph' };
+		}
 
 		// 3) Level-Regeln (anpassbar)
 		const allowParent = {
@@ -313,7 +317,13 @@ export const ItemManager = {
 			// Parent ist das Ziel (oder Root bei null)
 			const parentType = targetItem ? targetItem.type : null;
 			const allowed = allowParent[sourceItem.type] || [];
-			return allowed.includes(parentType);
+			if (!allowed.includes(parentType)) {
+				const reason = this.isHeadlineType(sourceItem.type) && parentType === 'h3'
+					? 'max-headline-depth'
+					: 'invalid-parent';
+				return { valid: false, reason };
+			}
+			return { valid: true };
 		}
 
 		// above/below: Parent wird der Parent des Ziel-Elements (oder Root)
@@ -323,16 +333,34 @@ export const ItemManager = {
 		// Same-Parent-Shortcut: reines Re-Order innerhalb derselben Gruppe IMMER erlauben
 		const currentParentId = sourceItem.parentId || null;
 		const newParentId = newParent ? newParent.id : null;
-		if (currentParentId === newParentId) return true;
+		if (currentParentId === newParentId) return { valid: true };
 
 		// Sonst Level-Regeln prüfen
 		const allowed = allowParent[sourceItem.type] || [];
-		if (!allowed.includes(newParentType)) return false;
+		if (!allowed.includes(newParentType)) {
+			const reason = this.isHeadlineType(sourceItem.type) && newParentType === 'h3'
+				? 'max-headline-depth'
+				: 'invalid-parent';
+			return { valid: false, reason };
+		}
 
-		// Root-Geschwister: nur h1 darf auf Root-Ebene liegen
-		if (newParentType === null && !this.isHeadlineType(sourceItem.type)) return false;
+		// Root-Geschwister: nur Headlines dürfen auf Root-Ebene liegen
+		if (newParentType === null && !this.isHeadlineType(sourceItem.type)) {
+			return { valid: false, reason: 'invalid-root' };
+		}
 
-		return true;
+		return { valid: true };
+	},
+
+	isValidDrop(sourceItem, targetItem, position) {
+		return this.getDropValidationResult(sourceItem, targetItem, position).valid;
+	},
+
+	getDropErrorMessage(reason) {
+		if (reason === 'max-headline-depth') {
+			return 'Maximale Gliederungstiefe erreicht: Unter H3 kann keine weitere Überschrift abgelegt werden.';
+		}
+		return 'Diese Aktion ist nicht erlaubt';
 	},
 
 
@@ -389,13 +417,13 @@ export const ItemManager = {
 	
 	canDropItem(sourceItemId, targetItemId, position) {
 		const list = StateManager.getCurrentList();
-		if (!list) return false;
+		if (!list) return { valid: false, reason: 'unbekannt' };
 
 		const sourceItem = this.findItemById(list.items, sourceItemId);
 		const targetItem = targetItemId ? this.findItemById(list.items, targetItemId) : null;
 
 	    //console.log("canDropItem:", "sourceItem:", sourceItem , "targetItem:", targetItem, "position:", position);
-		return this.isValidDrop(sourceItem, targetItem, position);
+		return this.getDropValidationResult(sourceItem, targetItem, position);
 	},
  
 
@@ -450,8 +478,9 @@ export const ItemManager = {
         }
         
         // Überprüfe, ob die Operation erlaubt ist
-        if (!this.canDropItem(itemId, targetItemId, position)) {
-            UIManager.showToast('Diese Aktion ist nicht erlaubt', 'error');
+        const dropValidation = this.canDropItem(itemId, targetItemId, position);
+        if (!dropValidation.valid) {
+            UIManager.showToast(this.getDropErrorMessage(dropValidation.reason), 'error');
             return;
         }
         

--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -46,6 +46,33 @@ function dependenciesEqual(a, b) {
 }
 
 export const ItemManager = {
+    isHeadlineType(type) {
+        return ['h1', 'h2', 'h3'].includes(type);
+    },
+
+    getHeadlineTypeByDepth(depth) {
+        if (depth <= 0) return 'h1';
+        if (depth === 1) return 'h2';
+        return 'h3';
+    },
+
+    normalizeHeadlineHierarchy(items, headlineDepth = 0) {
+        if (!Array.isArray(items)) return;
+
+        items.forEach(item => {
+            const isHeadline = this.isHeadlineType(item.type);
+            const nextDepth = isHeadline ? headlineDepth + 1 : headlineDepth;
+
+            if (isHeadline) {
+                item.type = this.getHeadlineTypeByDepth(headlineDepth);
+            }
+
+            if (Array.isArray(item.children) && item.children.length > 0) {
+                this.normalizeHeadlineHierarchy(item.children, nextDepth);
+            }
+        });
+    },
+
     addItem(type, parentId = null, initialData = null) {
 
     HelperManager.showHelpTo('hilfe-item-add');
@@ -92,6 +119,7 @@ export const ItemManager = {
             }
             
             list.meta.lastModified = new Date().toISOString();
+            this.normalizeHeadlineHierarchy(list.items);
             return project;
         });
         
@@ -272,10 +300,10 @@ export const ItemManager = {
 
 		// 3) Level-Regeln (anpassbar)
 		const allowParent = {
-			h1: [null],           // h1 nur als Root
-			h2: ['h1'],           // h2 nur unter h1
-			h3: ['h2'],           // h3 nur unter h2
-			p:  ['h1','h2','h3'], // p unter jeder Headline
+			h1: [null, 'h1', 'h2', 'h3'],
+			h2: [null, 'h1', 'h2', 'h3'],
+			h3: [null, 'h1', 'h2', 'h3'],
+			p: ['h1', 'h2', 'h3'],
 		};
 
 		// Helper zum Ermitteln des Parent-Typs
@@ -302,7 +330,7 @@ export const ItemManager = {
 		if (!allowed.includes(newParentType)) return false;
 
 		// Root-Geschwister: nur h1 darf auf Root-Ebene liegen
-		if (newParentType === null && sourceItem.type !== 'h1') return false;
+		if (newParentType === null && !this.isHeadlineType(sourceItem.type)) return false;
 
 		return true;
 	},
@@ -477,6 +505,9 @@ export const ItemManager = {
 
         // 6) Sort-Indices unter neuen Geschwistern neu durchzählen
         siblings.forEach((el, idx) => { el.sort = idx; });
+
+        // 6b) Headline-Typen aus der tatsächlichen Gliederung ableiten
+        this.normalizeHeadlineHierarchy(list.items);
 
         // 7) Projekt-Metadaten + UI
         list.meta.lastModified = new Date().toISOString();

--- a/app/uiManager.js
+++ b/app/uiManager.js
@@ -1047,8 +1047,9 @@ const commentCount = item.comments?.length || 0;
 
             // Selbst-Ziel-Schutz (optional, verhindert No-Op oder inkonsistente Moves)
             if (targetItemId === itemId && position !== 'into') return;
-            if (!ItemManager.canDropItem(itemId, targetItemId, position)) {
-                UIManager.showToast('Diese Aktion ist nicht erlaubt', 'error');
+            const dropValidation = ItemManager.canDropItem(itemId, targetItemId, position);
+            if (!dropValidation.valid) {
+                UIManager.showToast(ItemManager.getDropErrorMessage(dropValidation.reason), 'error');
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Ziel ist, die bisher festen Headline-Typen (`h1`/`h2`/`h3`) aufzulösen und Headline-Ebenen aus der tatsächlichen Baumstruktur abzuleiten, damit Headlines per Drag & Drop ihre richtige Ebene bekommen. 
- Aktuelle Einschränkungen verhinderten das sinnvolle Verschieben von Überschriften (z. B. ein H3 zu Root verschieben und es automatisch zu H1 machen). 
- Die Änderung soll die Gliederung konsistent halten und die Bedienung bei Umstrukturierungen erleichtern.

### Description
- Neue Hilfsmethoden in `ItemManager`: `isHeadlineType`, `getHeadlineTypeByDepth` und `normalizeHeadlineHierarchy` implementiert, die rekursiv die tatsächliche Verschachtelung in `h1`/`h2`/`h3` abbilden. 
- Die Normalisierung wird nach dem Anlegen (`addItem`) und nach Verschieben (`moveItem`) der Items ausgeführt, sodass Headline-Typen immer der realen Gliederung entsprechen. 
- Drag-&-Drop-Regeln wurden gelockert: Headlines dürfen nun unter/zwischen anderen Headlines frei verschoben werden (die Validierung nutzt jetzt `isHeadlineType` statt harter Typchecks), während `p` weiterhin nur unter Headlines erlaubt ist. 

### Testing
- Validierung: `node --check app/itemManager.js` wurde ausgeführt und lieferte keine Fehler. 
- Keine weitere automatisierte Test-Suite vorhanden; Änderungen sind lokal syntaktisch geprüft worden (`node --check`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f6decce48328a25692499845193c)