### PR TITLE
Planspiel: Protokollierung entferkter Felder und Strukturänderungen beim Übernehmen

### DIFF
--- a/app/planModeManager.js
+++ b/app/planModeManager.js
@@ -86,10 +86,28 @@ console.log("🔍 Beispiel afterItem:", afterItems[0]);
       }
 
       const diff = {};
-      for (const key of Object.keys(afterItem.data || {})) {
+      const beforeData = beforeItem.data || {};
+      const afterData = afterItem.data || {};
+      const allDataKeys = new Set([
+        ...Object.keys(beforeData),
+        ...Object.keys(afterData)
+      ]);
+
+      for (const key of allDataKeys) {
         if (!deepEqual(beforeItem.data?.[key], afterItem.data?.[key])) {
           diff[key] = [beforeItem.data?.[key], afterItem.data?.[key]];
         }
+      }
+
+      // Strukturänderungen außerhalb von data erfassen
+      if (!deepEqual(beforeItem.parentId, afterItem.parentId)) {
+        diff.parentId = [beforeItem.parentId ?? null, afterItem.parentId ?? null];
+      }
+      if (!deepEqual(beforeItem.sort, afterItem.sort)) {
+        diff.sort = [beforeItem.sort ?? null, afterItem.sort ?? null];
+      }
+      if (!deepEqual(beforeItem.type, afterItem.type)) {
+        diff.type = [beforeItem.type ?? null, afterItem.type ?? null];
       }
 
       if (Object.keys(diff).length > 0) {
@@ -119,9 +137,18 @@ console.log("🔍 Beispiel afterItem:", afterItems[0]);
     }
 
     // 🔍 Grund abfragen (optional)
-    const specialChanges = changeBuffer.filter(c =>
-      Object.keys(c.changes).some(k => ["report_deadline", "estimated_duration"].includes(k))
-    );
+    const specialChanges = changeBuffer.filter(c => {
+      if (c.action === "CREATE") {
+        const createdItem = c.changes?.item;
+        return ["report_deadline", "estimated_duration"].some(key =>
+          createdItem?.data?.[key] != null
+        );
+      }
+
+      return Object.keys(c.changes || {}).some(k =>
+        ["report_deadline", "estimated_duration"].includes(k)
+      );
+    });
 
     let globalReason = null;
     if (specialChanges.length > 0) {


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass beim Übernehmen eines Planspiels alle relevanten Änderungen (auch entfernte Felder und Strukturänderungen wie Verschiebungen) korrekt in die Projekt-Historie übernommen und protokolliert werden. 

### Description
- Vergleiche beim Commit jetzt die Vereinigungsmenge der Keys aus `beforeItem.data` und `afterItem.data`, sodass entfernte Felder erkannt und geloggt werden. 
- Strukturelle Änderungen außerhalb von `data` werden nun ebenfalls als `UPDATE` erfasst, konkret `parentId`, `sort` und `type`. 
- Die Erkennung „wesentlicher Änderungen“ wurde für `CREATE`-Einträge erweitert, sodass neu angelegte Items mit `report_deadline` oder `estimated_duration` die Begründungsabfrage auslösen. 

### Testing
- `node --check app/planModeManager.js` wurde ausgeführt und ohne Syntaxfehler bestanden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc0b63208328a60665ca3333cf69)