### PR TITLE
Add extensible admin settings backend and dedicated settings page

### DIFF
--- a/admin_settings.php
+++ b/admin_settings.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+ini_set('session.use_strict_mode', '1');
+session_start([
+  'cookie_httponly' => true,
+  'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+  'cookie_samesite' => 'Lax',
+  'use_strict_mode' => true,
+]);
+if (!isset($_SESSION['uid'])) { header('Location: /listify/login.php'); exit; }
+?><!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Listify – Systemeinstellungen</title>
+  <link rel="stylesheet" href="/listify/assets/admin.css">
+  <style>
+    .container{max-width:95%;margin:40px auto;background:#fff;border-radius:16px;padding:24px;color:#0f172a}
+    .topbar{display:flex;justify-content:space-between;align-items:center;color:#fff;padding:16px}
+    .link{color:#fff;text-decoration:underline}
+    .admin-nav{display:flex;gap:8px;margin-bottom:20px;flex-wrap:wrap}
+    .admin-nav a{padding:8px 12px;border-radius:8px;background:#e2e8f0;color:#0f172a;text-decoration:none;font-weight:600}
+    .admin-nav a.active{background:#0f172a;color:#fff}
+    .settings-grid{display:grid;grid-template-columns:minmax(220px,280px) 1fr;gap:20px}
+    .section-list{border:1px solid #dbe1ea;border-radius:10px;padding:10px;height:max-content}
+    .section-item{display:block;width:100%;text-align:left;border:0;background:#f8fafc;border-radius:8px;padding:10px;margin-bottom:8px;cursor:pointer}
+    .section-item.active{background:#cfe1ff}
+    .editor{border:1px solid #dbe1ea;border-radius:10px;padding:14px}
+    textarea{width:100%;min-height:420px;font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:13px;border:1px solid #d0d6e0;border-radius:8px;padding:10px}
+    .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:10px}
+    .btn{padding:8px 12px;border-radius:8px;border:0;background:#0f172a;color:#fff;cursor:pointer}
+    .btn.secondary{background:#e2e8f0;color:#0f172a}
+    .hint{font-size:12px;color:#475569;margin-top:8px}
+    @media (max-width:900px){.settings-grid{grid-template-columns:1fr}}
+  </style>
+</head>
+<body class="splash-bg">
+  <div class="topbar">
+    <div><strong>listify</strong> – Adminbereich</div>
+    <div><a class="link" href="/listify/">Zurück zur App</a></div>
+  </div>
+
+  <div class="container">
+    <nav class="admin-nav" aria-label="Admin Navigation">
+      <a href="/listify/user_admin.php">Userverwaltung</a>
+      <a href="/listify/admin_settings.php" class="active">Einstellungen</a>
+    </nav>
+
+    <h1 style="margin-top:0">Systemeinstellungen</h1>
+    <div class="settings-grid">
+      <div class="section-list" id="section-list"></div>
+      <div class="editor">
+        <h2 id="section-title" style="margin-top:0">Bereich wählen</h2>
+        <p id="section-description"></p>
+        <textarea id="settings-json" aria-label="Settings JSON"></textarea>
+        <div class="actions">
+          <button class="btn secondary" id="btn-reload" type="button">Neu laden</button>
+          <button class="btn" id="btn-save" type="button">Speichern</button>
+        </div>
+        <div class="hint">Das Settings-System ist bereichsbasiert. Neue Bereiche können serverseitig in der Registry ergänzt werden und erscheinen automatisch in dieser Navigation.</div>
+      </div>
+    </div>
+  </div>
+
+  <script src="/listify/assets/admin-settings.js" defer></script>
+</body>
+</html>

--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -161,3 +161,101 @@ function load_app_settings(): array {
   $data = json_decode($raw ?: '{}', true);
   return is_array($data) ? $data : [];
 }
+
+function load_json_file(string $file, array $fallback = []): array {
+  if (!file_exists($file)) return $fallback;
+  $raw = file_get_contents($file);
+  $data = json_decode($raw ?: '{}', true);
+  return is_array($data) ? $data : $fallback;
+}
+
+function save_json_file(string $file, array $data): void {
+  $dir = dirname($file);
+  if (!is_dir($dir)) {
+    json_err('Zielverzeichnis für Einstellungen fehlt', 500);
+  }
+
+  $fp = fopen($file, 'c+');
+  if (!$fp) json_err('Einstellungsdatei kann nicht geöffnet werden', 500);
+  flock($fp, LOCK_EX);
+  ftruncate($fp, 0);
+  fwrite($fp, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+  fflush($fp);
+  flock($fp, LOCK_UN);
+  fclose($fp);
+}
+
+function settings_registry(): array {
+  return [
+    'registration' => [
+      'title' => 'Registrierung',
+      'description' => 'Steuert Registrierung, Freigabe-Modus und verfügbare Abteilungen.',
+      'file' => __DIR__ . '/../data/settings.json',
+      'default' => [
+        'registration_mode' => 'approval',
+        'departments' => [],
+      ],
+    ],
+    'listify_defaults' => [
+      'title' => 'Listify Standardwerte',
+      'description' => 'Globale Vorgaben für die App (default_config.json).',
+      'file' => __DIR__ . '/../app/default_config.json',
+      'default' => [],
+    ],
+  ];
+}
+
+function get_settings_section(string $key): ?array {
+  $registry = settings_registry();
+  if (!isset($registry[$key])) return null;
+
+  $section = $registry[$key];
+  return [
+    'key' => $key,
+    'title' => $section['title'],
+    'description' => $section['description'],
+    'data' => load_json_file($section['file'], $section['default']),
+  ];
+}
+
+function validate_settings_payload(string $key, array $payload): array {
+  if ($key === 'registration') {
+    $mode = (string)($payload['registration_mode'] ?? 'approval');
+    if (!in_array($mode, ['open', 'approval', 'closed'], true)) {
+      json_err('Ungültiger registration_mode. Erlaubt: open, approval, closed', 422);
+    }
+
+    $departments = $payload['departments'] ?? [];
+    if (!is_array($departments)) {
+      json_err('departments muss ein Array sein', 422);
+    }
+
+    $cleanDepartments = [];
+    foreach ($departments as $department) {
+      if (!is_string($department)) {
+        json_err('departments darf nur Strings enthalten', 422);
+      }
+      $trimmed = trim($department);
+      if ($trimmed !== '') {
+        $cleanDepartments[] = $trimmed;
+      }
+    }
+
+    return [
+      'registration_mode' => $mode,
+      'departments' => array_values(array_unique($cleanDepartments)),
+    ];
+  }
+
+  return $payload;
+}
+
+function save_settings_section(string $key, array $payload): void {
+  $registry = settings_registry();
+  if (!isset($registry[$key])) {
+    json_err('Unbekannter Settings-Bereich', 404);
+  }
+
+  $sanitized = validate_settings_payload($key, $payload);
+  save_json_file($registry[$key]['file'], $sanitized);
+}

--- a/api/admin/settings/get.php
+++ b/api/admin/settings/get.php
@@ -1,0 +1,22 @@
+<?php
+require __DIR__ . '/../../_bootstrap.php';
+
+require_admin();
+
+$key = trim((string)($_GET['section'] ?? ''));
+
+if ($key !== '') {
+  $section = get_settings_section($key);
+  if ($section === null) json_err('Unbekannter Settings-Bereich', 404);
+  json_ok(['section' => $section]);
+}
+
+$sections = [];
+foreach (array_keys(settings_registry()) as $sectionKey) {
+  $section = get_settings_section($sectionKey);
+  if ($section !== null) {
+    $sections[] = $section;
+  }
+}
+
+json_ok(['sections' => $sections]);

--- a/api/admin/settings/save.php
+++ b/api/admin/settings/save.php
@@ -1,0 +1,21 @@
+<?php
+require __DIR__ . '/../../_bootstrap.php';
+
+require_admin();
+verify_csrf();
+
+$in = json_decode(file_get_contents('php://input'), true);
+if (!is_array($in)) json_err('Ungültiger JSON-Body', 422);
+
+$key = trim((string)($in['section'] ?? ''));
+$payload = $in['data'] ?? null;
+
+if ($key === '') json_err('section fehlt', 422);
+if (!is_array($payload)) json_err('data muss ein Objekt sein', 422);
+
+save_settings_section($key, $payload);
+
+$section = get_settings_section($key);
+if ($section === null) json_err('Unbekannter Settings-Bereich', 404);
+
+json_ok(['section' => $section]);

--- a/api/public/settings/registration.php
+++ b/api/public/settings/registration.php
@@ -1,0 +1,11 @@
+<?php
+require __DIR__ . '/../../_bootstrap.php';
+
+$section = get_settings_section('registration');
+if ($section === null) json_err('Settings nicht gefunden', 404);
+
+$data = $section['data'];
+json_ok([
+  'registration_mode' => $data['registration_mode'] ?? 'approval',
+  'departments' => $data['departments'] ?? [],
+]);

--- a/assets/admin-settings.js
+++ b/assets/admin-settings.js
@@ -1,0 +1,117 @@
+let csrfToken = null;
+let sections = [];
+let activeSection = null;
+
+const sectionListEl = document.getElementById('section-list');
+const sectionTitleEl = document.getElementById('section-title');
+const sectionDescriptionEl = document.getElementById('section-description');
+const editorEl = document.getElementById('settings-json');
+
+async function loadMe() {
+  const r = await fetch('/listify/api/auth/me.php', { credentials: 'include' });
+  const j = await r.json();
+  if (!j.ok || !j.data?.authenticated || j.data?.user?.role !== 'admin') {
+    alert('Adminrechte erforderlich');
+    location.href = '/listify/login.php';
+    return false;
+  }
+  csrfToken = j.data.csrf;
+  return true;
+}
+
+async function loadSections() {
+  const r = await fetch('/listify/api/admin/settings/get.php', { credentials: 'include' });
+  const j = await r.json();
+  if (!j.ok) {
+    alert(j.error || 'Settings konnten nicht geladen werden');
+    return;
+  }
+  sections = j.data.sections || [];
+  renderSections();
+  if (sections.length > 0) {
+    selectSection(sections[0].key);
+  }
+}
+
+function renderSections() {
+  sectionListEl.innerHTML = '';
+  sections.forEach((section) => {
+    const btn = document.createElement('button');
+    btn.className = `section-item${activeSection === section.key ? ' active' : ''}`;
+    btn.type = 'button';
+    btn.textContent = section.title;
+    btn.addEventListener('click', () => selectSection(section.key));
+    sectionListEl.appendChild(btn);
+  });
+}
+
+function selectSection(key) {
+  const section = sections.find((s) => s.key === key);
+  if (!section) return;
+  activeSection = key;
+  sectionTitleEl.textContent = section.title;
+  sectionDescriptionEl.textContent = section.description || '';
+  editorEl.value = JSON.stringify(section.data ?? {}, null, 2);
+  renderSections();
+}
+
+async function reloadActiveSection() {
+  if (!activeSection) return;
+  const r = await fetch(`/listify/api/admin/settings/get.php?section=${encodeURIComponent(activeSection)}`, { credentials: 'include' });
+  const j = await r.json();
+  if (!j.ok) {
+    alert(j.error || 'Bereich konnte nicht neu geladen werden');
+    return;
+  }
+
+  const idx = sections.findIndex((s) => s.key === activeSection);
+  if (idx >= 0) {
+    sections[idx] = j.data.section;
+  }
+  selectSection(activeSection);
+}
+
+async function saveActiveSection() {
+  if (!activeSection) return;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(editorEl.value);
+  } catch (error) {
+    alert(`JSON ungültig: ${error.message}`);
+    return;
+  }
+
+  const r = await fetch('/listify/api/admin/settings/save.php', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfToken,
+    },
+    body: JSON.stringify({ section: activeSection, data: parsed }),
+  });
+
+  const j = await r.json();
+  if (!j.ok) {
+    alert(j.error || 'Speichern fehlgeschlagen');
+    return;
+  }
+
+  const idx = sections.findIndex((s) => s.key === activeSection);
+  if (idx >= 0) {
+    sections[idx] = j.data.section;
+  }
+
+  selectSection(activeSection);
+  alert('Settings gespeichert');
+}
+
+document.getElementById('btn-reload')?.addEventListener('click', reloadActiveSection);
+document.getElementById('btn-save')?.addEventListener('click', saveActiveSection);
+
+(async function init() {
+  const ok = await loadMe();
+  if (!ok) return;
+  await loadSections();
+})();

--- a/assets/register.js
+++ b/assets/register.js
@@ -1,8 +1,8 @@
 async function loadDepartments() {
   try {
-    const res = await fetch('/listify/data/settings.json'); // öffentlich lesbar?
-    const settings = await res.json();
-    const departments = settings.departments || [];
+    const res = await fetch('/listify/api/public/settings/registration.php'); // öffentlich lesbar?
+    const payload = await res.json();
+    const departments = payload?.data?.departments || [];
     const sel = document.getElementById('department');
     departments.forEach(d => {
       const opt = document.createElement('option');

--- a/assets/user-admin.js
+++ b/assets/user-admin.js
@@ -131,9 +131,9 @@ async function delUser(id) {
 
 async function loadDepartmentsSelect(selectId, currentValue="") {
   try {
-    const res = await fetch('/listify/data/settings.json', {cache:"no-cache"});
-    const settings = await res.json();
-    const departments = settings.departments || [];
+    const res = await fetch('/listify/api/public/settings/registration.php', {cache:"no-cache"});
+    const payload = await res.json();
+    const departments = payload?.data?.departments || [];
     const sel = document.getElementById(selectId);
     if (!sel) return;
 

--- a/user_admin.php
+++ b/user_admin.php
@@ -63,6 +63,10 @@ if (!isset($_SESSION['uid'])) { header('Location: /listify/login.php'); exit; }
     <div><a class="link" href="/listify/">Zurück zur App</a></div>
   </div>
   <div class="container">
+    <nav style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px" aria-label="Admin Navigation">
+      <a style="padding:8px 12px;border-radius:8px;background:#0f172a;color:#fff;text-decoration:none;font-weight:600" href="/listify/user_admin.php">Userverwaltung</a>
+      <a style="padding:8px 12px;border-radius:8px;background:#e2e8f0;color:#0f172a;text-decoration:none;font-weight:600" href="/listify/admin_settings.php">Einstellungen</a>
+    </nav>
     <div class="toolbar">
       <div class="row">
         <input id="first_name" placeholder="Vorname" aria-label="Vorname">


### PR DESCRIPTION
### Motivation
- Implementiere ein dediziertes Settings-System, das nicht in der Userverwaltung liegt und neue Bereiche einfach ergänzt.  
- Vermeide direkten Frontend-Zugriff auf `data/settings.json` und stelle nur notwendige, öffentliche Einstellungen über eine API bereit.  
- Ermögliche künftig erweiterbare Settings-Bereiche (z.B. Listify-Defaults) mit zentraler Server-Registry.

### Description
- Ergänzt `settings_registry()` und JSON-Helper (`load_json_file`, `save_json_file`, `get_settings_section`, `save_settings_section`, `validate_settings_payload`) in `api/_bootstrap.php` zur zentralen Verwaltung von Settings-Bereichen und Validierung.  
- Neue Admin-APIs: `GET api/admin/settings/get.php` zum Auflisten/Auslesen von Bereichen und `POST api/admin/settings/save.php` zum Speichern mit `require_admin()`- und CSRF-Schutz.  
- Neue öffentliche API `GET api/public/settings/registration.php` liefert nur die für Registrierung benötigten Felder (`registration_mode`, `departments`) für Frontend-Nutzung.  
- Neue Admin-Seite `admin_settings.php` mit JSON-Editor und Bereichs-Navigation sowie zugehöriges `assets/admin-settings.js` für Laden, Editieren, Reload und Speichern der Bereiche.  
- Frontend-Anpassungen: `assets/register.js` und `assets/user-admin.js` nutzen jetzt die neue öffentliche Registration-API statt direkten Datei-Zugriffs, und `user_admin.php` bekam ein Admin-Navigationsmenü zur Verlinkung der Einstellungen.

### Testing
- ✅ Syntax-Checks per `php -l` für `api/_bootstrap.php`, `api/admin/settings/get.php`, `api/admin/settings/save.php`, `api/public/settings/registration.php`, `admin_settings.php` und `user_admin.php` (keine Syntax-Fehler).  
- ⚠️ Versuchte automatisierte Seitenaufnahme von `/admin_settings.php` schlug fehl wegen Redirect-Loop beim Zugriff ohne gültige Admin-Session (`ERR_TOO_MANY_REDIRECTS`).  
- ✅ Playwright-Screenshot von `/login.php` wurde erfolgreich erstellt, was bestätigte, dass der Entwicklungsserver erreichbar ist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a691bd0b288328aef206fe3bc24811)