### PR TITLE
Activate help mode when opening contextual help

### DIFF
--- a/app/helperManager.js
+++ b/app/helperManager.js
@@ -93,13 +93,14 @@ export const HelperManager = {
       if (!topicId) return;
 
       event.preventDefault();
+      this.setMode(true);
       this.showHelpTo(topicId, { forceOpen: true });
     });
 
     document.addEventListener('keydown', (event) => {
       if (event.key !== 'F1') return;
       event.preventDefault();
-      this.openSidebar();
+      this.setMode(true);
     });
 
     this.contextHelpBound = true;


### PR DESCRIPTION
### Motivation
- Contextual help triggers (`data-help-topic` clicks and `F1`) should activate the global help mode so the UI applies `body.help-mode` (content is narrowed instead of the sidebar merely overlaying content).

### Description
- Added `this.setMode(true)` to the click handler for `[data-help-topic]` so the help mode is enabled before calling `showHelpTo(...)` in `app/helperManager.js`.
- Replaced the direct `openSidebar()` call in the `F1` key handler with `this.setMode(true)` so the existing `setMode` logic opens the sidebar and keeps behavior consistent.
- Changes are limited to `app/helperManager.js` and preserve the existing sidebar/offcanvas rendering flow.

### Testing
- Ran `node --check app/helperManager.js` to validate syntax and it succeeded. 
- Launched a local test server with `python3 -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot (`artifacts/help-mode-sidebar.png`) to validate the UI state; the screenshot run completed successfully. 
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7483cc1cc8328bc36fbb3431a4698)