### PR TITLE
Fix collapse scope for nested heading groups

### DIFF
--- a/app/collapseManager.js
+++ b/app/collapseManager.js
@@ -32,15 +32,15 @@
   const sessionState = Object.create(null); // { [id: string]: boolean }  true = collapsed
 
   const getChildrenBox = (headerCard) => {
-    let el = headerCard.nextElementSibling;
-    while (el && !el.classList.contains('children-container')) el = el.nextElementSibling;
-    return el || null;
+    const el = headerCard.nextElementSibling;
+    return (el && el.classList.contains('children-container')) ? el : null;
   };
 
   const ensureToggles = () => {
     if (!ROOT) return;
     ROOT.querySelectorAll('.item-card.item-h1, .item-card.item-h2, .item-card.item-h3').forEach(card => {
       if (card.querySelector('.toggle-children-btn')) return;
+      if (!getChildrenBox(card)) return; // Nur Header mit eigenen Kindern einklappbar machen
       const title = card.querySelector('.card-title');
       if (!title) return;
       const btn = document.createElement('button');


### PR DESCRIPTION
### Motivation
- Headings with the collapse control were collapsing unrelated groups because the child-container lookup walked past intermediate nodes; a heading should only toggle its immediate children container.

### Description
- Change `getChildrenBox` to only return the directly following sibling when it has class `children-container` and skip injecting a toggle button for headers where `getChildrenBox` returns `null`.

### Testing
- Ran `node --check app/collapseManager.js` which completed successfully.
- Attempted a Playwright screenshot test to validate UI behavior but the headless browser failed to start (SIGSEGV), so no browser-driven screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a956591a0083289a9e7913842c1144)