### PR TITLE
Show Advanced Mode banner and sync body class with switch

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -264,8 +264,10 @@ const advancedSwitch = document.getElementById('advancedModeSwitch');
 if (advancedSwitch) {
     advancedSwitch.checked = false;
     StateManager.setAdvancedModeActive(false);
+    document.body.classList.remove('advancedmode');
     advancedSwitch.addEventListener('change', (e) => {
         StateManager.setAdvancedModeActive(e.target.checked);
+        document.body.classList.toggle('advancedmode', e.target.checked);
         UIManager.updateLists(StateManager.getCurrentProject()?.lists || {});
         const currentList = StateManager.getCurrentList();
         if (currentList?.meta?.id) {

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -355,16 +355,42 @@
 
 body.planmode::before {
   content: "⚠️ Planspielmodus aktiv – Änderungen werden nicht gespeichert!";
-  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   background: #ffeb3b;
   color: #000;
   text-align: center;
   font-weight: bold;
   padding: 0.3rem;
+  z-index: 2000;
+  pointer-events: none;
+}
+
+
+body.advancedmode::after {
+  content: "⚠️ Erweiterter Modus aktiv";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #ffd6d6;
+  color: #000;
+  text-align: center;
+  font-weight: bold;
+  padding: 0.3rem;
+  z-index: 1999;
+  pointer-events: none;
 }
 
 .deleted-entry {
     opacity: 0.65;
     border-style: dashed !important;
     filter: grayscale(0.2);
+}
+
+
+body.planmode.advancedmode::after {
+  top: 2.1rem;
 }


### PR DESCRIPTION
### Motivation
- Provide a persistent visual indicator when the "Advanced Mode" is enabled so users can clearly see the current mode.  
- Ensure the DOM reflects the `advancedMode` state so CSS can show/hide the indicator consistently.  
- Prevent the Advanced Mode banner from visually colliding with the existing Plan Mode banner when both modes are active.  

### Description
- Initialize the `advancedModeSwitch` state by removing `advancedmode` from `document.body` and set `StateManager.setAdvancedModeActive(false)` on startup.  
- Toggle `document.body.classList` with `advancedmode` in the `advancedModeSwitch` change handler via `document.body.classList.toggle('advancedmode', e.target.checked)` so the UI updates with mode changes.  
- Add new CSS rules for `body.advancedmode::after` to render a fixed banner and update `body.planmode::before` to be fixed with proper `z-index` and `pointer-events` settings.  
- Add a layout adjustment rule `body.planmode.advancedmode::after` to offset the Advanced Mode banner when Plan Mode is also active.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95f2f99e4832885911ca298504515)