### PR TITLE
Add DebugLogger and centralize debug output; add configurable `debuggingMode`

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -48,6 +48,7 @@ import { GanttManager } from './ganttManager.js';
 import { AuthManager } from './AuthManager.js';
 import { PlanModeManager } from './planModeManager.js';
 import { StateManager } from './stateManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 
 
@@ -91,7 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
         })
         .catch(err => {
-            console.error("Auth Fehler:", err);
+            DebugLogger.error("Auth Fehler:", err);
         });
     
      // Logout-Handler
@@ -127,7 +128,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             await ProjectManager.createNewProject();
         } catch (error) {
-            console.error('Fehler beim Erstellen des Projekts:', error);
+            DebugLogger.error('Fehler beim Erstellen des Projekts:', error);
             UIManager.showToast('Fehler beim Projekt erstellen', 'error');
         }
     });
@@ -137,7 +138,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             await ProjectManager.saveProject();
         } catch (error) {
-            console.error('Fehler beim Speichern:', error);
+            DebugLogger.error('Fehler beim Speichern:', error);
             UIManager.showToast('Fehler beim Speichern: ' + error.message, 'error');
         }
     });

--- a/app/comparisonManager.js
+++ b/app/comparisonManager.js
@@ -28,6 +28,7 @@ import { formatDate } from './utils.js'
 
 import { UIManager } from './uiManager.js';
 import { Programm } from './programm.js';
+import { DebugLogger } from './debugLogger.js';
 
 
 
@@ -181,8 +182,8 @@ async startComparison({ mode, snapshotA, snapshotB, template, showReasons }) {
     UIManager.showToast('Snapshot(s) nicht gefunden', 'error');
     return;
   }
-console.log('Snapshot A:', snapA.data);
-console.log('Snapshot B:', snapB.data);
+DebugLogger.log('Snapshot A:', snapA.data);
+DebugLogger.log('Snapshot B:', snapB.data);
 
   // Vergleich vorbereiten
   const comparisonData = this.prepareComparisonData(
@@ -191,7 +192,7 @@ console.log('Snapshot B:', snapB.data);
     mode === 'snapshot-vs-snapshot' ? 'snapshot-vs-snapshot' : 'list-vs-snapshot'
   );
 
-  console.log('Vergleichsdaten:', comparisonData); // ← Hinzufügen
+  DebugLogger.log('Vergleichsdaten:', comparisonData); // ← Hinzufügen
   // PDF erzeugen
   try {
     await generateComparisonPDF(comparisonData, {
@@ -206,7 +207,7 @@ console.log('Snapshot B:', snapB.data);
 
 
   } catch (err) {
-    console.error('Fehler beim Vergleichs-PDF:', err);
+    DebugLogger.error('Fehler beim Vergleichs-PDF:', err);
     UIManager.showToast('Fehler beim PDF-Vergleich', 'error');
   }
 },
@@ -449,7 +450,7 @@ export async function generateComparisonPDF(comparisonData, options = {}) {
         height: logoHeight,
       });
     } catch (e) {
-      console.warn('Logo konnte nicht geladen werden:', e);
+      DebugLogger.warn('Logo konnte nicht geladen werden:', e);
     }
 
 
@@ -880,7 +881,7 @@ for (const entry of headlines) {
             }
 
 if (options.showReasons && row.reason) {
-            console.log("reason: ", row.reason);
+            DebugLogger.log("reason: ", row.reason);
             // Änderungsgrund ausgeben
          
             drawReasonBox(row.reason);

--- a/app/debugConsole.js
+++ b/app/debugConsole.js
@@ -1,0 +1,8 @@
+/**
+ * DEPRECATED: Wird nicht mehr verwendet.
+ * Konsolenausgaben werden zentral über DebugLogger gesteuert.
+ */
+
+export function initDebugConsole() {
+    // absichtlich leer
+}

--- a/app/debugLogger.js
+++ b/app/debugLogger.js
@@ -1,0 +1,36 @@
+/**
+ * Listify – Community Edition
+ */
+
+let debuggingEnabled = false;
+
+function toBoolean(value) {
+    return value === true || value === 'true';
+}
+
+export function setDebuggingMode(enabled) {
+    debuggingEnabled = toBoolean(enabled);
+}
+
+export const DebugLogger = {
+    log(...args) {
+        if (!debuggingEnabled) return;
+        console.log(...args);
+    },
+    info(...args) {
+        if (!debuggingEnabled) return;
+        console.info(...args);
+    },
+    warn(...args) {
+        if (!debuggingEnabled) return;
+        console.warn(...args);
+    },
+    error(...args) {
+        if (!debuggingEnabled) return;
+        console.error(...args);
+    },
+    debug(...args) {
+        if (!debuggingEnabled) return;
+        console.debug(...args);
+    }
+};

--- a/app/default_config.json
+++ b/app/default_config.json
@@ -1,24 +1,23 @@
 {
-"itemEditor_createdate_DateOnly": "true",
-"itemEditor_deadline_DateOnly": "true", 
-"commentCategories": [
-  "Telefonat",
-  "Anweisung / Entscheidung",
-  "Besprechung / Meeting",
-  "E-Mail / Schriftverkehr",
-  "Rückfrage / Klärung",
-  "Änderungsgrund",
-  "Hinweis / Sonstiges"
-],
-"commentLimit": 150,
-"lists_phase": {
-  "1": "Projektvorbereitung",
-  "2": "Planung",
-  "3": "Ausführungsvorbereitung",
-  "4": "Ausführung",
-  "5": "Projektabschluss",
-  
-  "10": "Sonstiges"
-}
-
+  "itemEditor_createdate_DateOnly": "true",
+  "itemEditor_deadline_DateOnly": "true",
+  "commentCategories": [
+    "Telefonat",
+    "Anweisung / Entscheidung",
+    "Besprechung / Meeting",
+    "E-Mail / Schriftverkehr",
+    "Rückfrage / Klärung",
+    "Änderungsgrund",
+    "Hinweis / Sonstiges"
+  ],
+  "commentLimit": 150,
+  "lists_phase": {
+    "1": "Projektvorbereitung",
+    "2": "Planung",
+    "3": "Ausführungsvorbereitung",
+    "4": "Ausführung",
+    "5": "Projektabschluss",
+    "10": "Sonstiges"
+  },
+  "debuggingMode": false
 }

--- a/app/exportExcelManager.js
+++ b/app/exportExcelManager.js
@@ -21,6 +21,7 @@
 import { StateManager } from './stateManager.js';
 import { formatDate } from './utils.js'
 import { UIManager } from './uiManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 const TABLE_HEADER = ['ID', 'Date', 'Topic / Desc', 'Zuständigkeit', 'Frist', 'Typ', 'Status'];
 const COLS = 7; // A..G
@@ -318,7 +319,7 @@ async function exportCurrentListToExcel() {
     XLSX.writeFile(wb, filename);
     UIManager?.showToast?.('Excel-Datei erstellt', 'success');
   } catch (err) {
-    console.error('Excel-Export Fehler:', err);
+    DebugLogger.error('Excel-Export Fehler:', err);
     UIManager?.showToast?.('Excel-Export fehlgeschlagen', 'danger');
   }
 }

--- a/app/exportManager2.js
+++ b/app/exportManager2.js
@@ -27,6 +27,7 @@ import { StateManager } from './stateManager.js';
 import { formatDate } from './utils.js'
 import { UIManager } from './uiManager.js';
 import { Programm } from './programm.js';
+import { DebugLogger } from './debugLogger.js';
 
 export const ExportManager2 = {
   showExportModal() {
@@ -130,7 +131,7 @@ export const ExportManager2 = {
   },
 
   exportList({ template, columns, filters }) {
-    console.log("template: ", template);
+    DebugLogger.log("template: ", template);
     switch (template) {
       case 'simple':
         //this.exportSimpleLayout(columns, filters);
@@ -149,7 +150,7 @@ export const ExportManager2 = {
     const project = StateManager.getCurrentProject();
     const changelog = project?.changelog || {};
    
-    console.log('Array:', list.items);
+    DebugLogger.log('Array:', list.items);
 
     if (!list || !project) return;
 
@@ -683,7 +684,7 @@ function drawMarkdownText(page, text, x, y, opts) {
             A: { Type: 'Action', S: 'URI', URI: uri },
           });
         } catch (e) {
-          console.warn('PDF-Link konnte nicht gesetzt werden:', e);
+          DebugLogger.warn('PDF-Link konnte nicht gesetzt werden:', e);
         }
       }
 
@@ -914,7 +915,7 @@ if (selectedStatus.length && !selectedStatus.includes(status)) continue;
         
 
         if ((showPredecessors || showSuccessors) && item.type === 'p') {
-            console.log('Item', item.data?.report_id, item.id, item.data?.dependencies);
+            DebugLogger.log('Item', item.data?.report_id, item.id, item.data?.dependencies);
           drawSuccessorPredexessorRow(item, flatItems);
         }
 
@@ -927,14 +928,14 @@ if (selectedStatus.length && !selectedStatus.includes(status)) continue;
               /*const changelogEntries = (changelog[item.id] || [])
                 .slice()
                 .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-                  console.log('Changelog-Einträge für', item.data.report_id, changelogEntries.length, changelogEntries);*/
+                  DebugLogger.log('Changelog-Einträge für', item.data.report_id, changelogEntries.length, changelogEntries);*/
  const entriesAsc = (changelog[item.id] || [])
    .filter(e => e.action === 'UPDATE')              // nur UPDATE betrachten
    .slice()
    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));  // aufsteigend
  // „Erstellung“ = ältester UPDATE → überspringen
  const changelogEntries = entriesAsc.slice(1).reverse();            // wieder absteigend für Ausgabe
- console.log('Changelog-Einträge (ohne Erstellung) für', item.data.report_id, changelogEntries.length, changelogEntries);
+ DebugLogger.log('Changelog-Einträge (ohne Erstellung) für', item.data.report_id, changelogEntries.length, changelogEntries);
               for (const entry of changelogEntries) {
                 //if (entry.action !== 'UPDATE') continue;
 

--- a/app/ganttManager.js
+++ b/app/ganttManager.js
@@ -26,6 +26,7 @@ import { StateManager } from './stateManager.js';
 import { calcAutoDeadline, calcEarliestStart } from './itemManager.js';
 import { UIManager } from './uiManager.js';
 import { HolidayManager } from './holidayManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 export const GanttManager = {
   showGantt() {
@@ -104,7 +105,7 @@ export const GanttManager = {
 
          const year = new Date().getFullYear();
   const holidays = await HolidayManager.getAllMarkedDays(year);
-console.log("Holidays an Frappe Gantt:", holidays);
+DebugLogger.log("Holidays an Frappe Gantt:", holidays);
 
         const container = document.getElementById("gantt-container");
         container.innerHTML = "";

--- a/app/helperManager.js
+++ b/app/helperManager.js
@@ -24,6 +24,7 @@
 
 import { HelperContent } from './helperContent.js';
 import {
+import { DebugLogger } from './debugLogger.js';
   findTopicById,
   getCategoryEntries,
   groupEntriesByCategory,
@@ -100,13 +101,13 @@ initContextHelp() {
     const topicExists = findTopicById(HelperContent, cleanId);
 
     if (!topicExists) {
-      console.warn('Abbruch: Artikel existiert nicht:', cleanId);
+      DebugLogger.warn('Abbruch: Artikel existiert nicht:', cleanId);
       return; // Hier stoppen wir, bevor das UI verändert wird
     }
     // ------------------------------------------------
 
     event.preventDefault();
-    console.log("Hilfsartikel gefunden: " + topicId);
+    DebugLogger.log("Hilfsartikel gefunden: " + topicId);
     
     document.body.classList.add('help-mode'); 
     this.showHelpTo(topicId, { forceOpen: true });
@@ -264,7 +265,7 @@ initContextHelp() {
 
     const topic = findTopicById(HelperContent, cleanId);
     if (!topic) {
-      console.warn('Keine Hilfe gefunden für:', cleanId);
+      DebugLogger.warn('Keine Hilfe gefunden für:', cleanId);
       return;
     }
 

--- a/app/historyManager.js
+++ b/app/historyManager.js
@@ -27,6 +27,7 @@ import { formatDate } from './utils.js'
 import { UIManager } from './uiManager.js';
 import { ItemManager } from './itemManager.js';
 import { SettingsManager } from './settingsManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 function prettyPrintField(field, value) {
     if (field === 'dependencies') {
@@ -84,7 +85,7 @@ isForceLogging() { return forceLogging; },
 
         const project = StateManager.getCurrentProject();
         if (!project) {
-            console.warn("HistoryManager.logChange: Kein aktuelles Projekt.");
+            DebugLogger.warn("HistoryManager.logChange: Kein aktuelles Projekt.");
             return;
         }
 
@@ -106,20 +107,20 @@ isForceLogging() { return forceLogging; },
         state.currentProject = project;
         }
 
-        console.log("📝 History-Eintrag hinzugefügt:", logEntry);
+        DebugLogger.log("📝 History-Eintrag hinzugefügt:", logEntry);
     },
 
 
 async forceLogChange(itemId, action, changes) {
   try {
-    console.log("⚙️ forceLogChange start", { itemId, forceLogging });
+    DebugLogger.log("⚙️ forceLogChange start", { itemId, forceLogging });
     forceLogging = true;
-    console.log("⚙️ forceLogging gesetzt:", forceLogging);
+    DebugLogger.log("⚙️ forceLogging gesetzt:", forceLogging);
     await this.logChange(itemId, action, changes);
-    console.log("✅ forceLogChange done", { forceLogging });
+    DebugLogger.log("✅ forceLogChange done", { forceLogging });
   } finally {
     forceLogging = false;
-    console.log("🔁 forceLogging reset:", forceLogging);
+    DebugLogger.log("🔁 forceLogging reset:", forceLogging);
   }
 },
 

--- a/app/holidayManager.js
+++ b/app/holidayManager.js
@@ -21,6 +21,7 @@
  * Hinweis:
  * - Externe Bibliotheken behalten ihre eigenen Lizenzen.
  */
+import { DebugLogger } from './debugLogger.js';
 
 // holidayManager.js
 export const HolidayManager = {
@@ -35,7 +36,7 @@ export const HolidayManager = {
         color: "#ffd9d9"
       }));
     }catch (err) {
-     console.warn("⚠️ Feiertage API nicht erreichbar:", err);
+     DebugLogger.warn("⚠️ Feiertage API nicht erreichbar:", err);
       return [];
     }
   },
@@ -61,7 +62,7 @@ export const HolidayManager = {
       });
       return days;
     }catch (err) {
-        console.warn("⚠️ Ferien API nicht erreichbar:", err);
+        DebugLogger.warn("⚠️ Ferien API nicht erreichbar:", err);
         return [];
     }
   },
@@ -85,7 +86,7 @@ export const HolidayManager = {
 
       return holidayMap;
     }catch (err) {
-            console.warn("⚠️ Fehler beim Laden der Feiertage/Ferien:", err);
+            DebugLogger.warn("⚠️ Fehler beim Laden der Feiertage/Ferien:", err);
           return { "#f0f0f0": "weekend" }; // Fallback nur Wochenende
     }
   }

--- a/app/itemManager.js
+++ b/app/itemManager.js
@@ -29,6 +29,7 @@ import { HistoryManager } from './historyManager.js';
 import { UIManager } from './uiManager.js';
 import { ListManager } from './listManager.js';
 import { HelperManager } from './helperManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 function dependenciesEqual(a, b) {
     if (!Array.isArray(a) || !Array.isArray(b)) return false;
@@ -422,7 +423,7 @@ export const ItemManager = {
 		const sourceItem = this.findItemById(list.items, sourceItemId);
 		const targetItem = targetItemId ? this.findItemById(list.items, targetItemId) : null;
 
-	    //console.log("canDropItem:", "sourceItem:", sourceItem , "targetItem:", targetItem, "position:", position);
+	    //DebugLogger.log("canDropItem:", "sourceItem:", sourceItem , "targetItem:", targetItem, "position:", position);
 		return this.getDropValidationResult(sourceItem, targetItem, position);
 	},
  
@@ -651,7 +652,7 @@ export function calcAutoDeadline(item, allItems) {
  */
 export function calcAutoDeadlineDeep(item, allItems, visited = new Set()) {
     if (visited.has(item.id)) {
-        console.warn("Zyklische Abhängigkeit entdeckt:", item.id);
+        DebugLogger.warn("Zyklische Abhängigkeit entdeckt:", item.id);
         return null;
     }
     visited.add(item.id);
@@ -743,8 +744,8 @@ export function calcAutoDeadlineDetails(item, allItems) {
     if (ownDuration && deadline) {
         deadline = addDuration(deadline, ownDuration.value, ownDuration.unit);
     }
-console.log("Item dependencies:", item.data.dependencies);
-console.log("Preds found:", preds);
+DebugLogger.log("Item dependencies:", item.data.dependencies);
+DebugLogger.log("Preds found:", preds);
     return {
 
 		

--- a/app/listManager.js
+++ b/app/listManager.js
@@ -27,6 +27,7 @@ import { generateUUID, formatDate} from './utils.js'
 
 import { UIManager, showConfirmDialog, PhaseHelper } from './uiManager.js';
 import { SettingsManager } from './settingsManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 export const ListManager = {
     async showListModal() {
@@ -334,14 +335,14 @@ export const ListManager = {
 
     _wireListOverviewHandlers() {
 
-          console.log('%c[Modal] _wireListOverviewHandlers gestartet', 'color: limegreen');
+          DebugLogger.log('%c[Modal] _wireListOverviewHandlers gestartet', 'color: limegreen');
 
         const modalBody = document.getElementById('modalBody');
-        console.log('[Modal] modalBody gefunden:', modalBody);
+        DebugLogger.log('[Modal] modalBody gefunden:', modalBody);
         if (!modalBody) return;
 
         const rows = modalBody.querySelectorAll('tbody tr[data-id]');
-        console.log('[Modal] Tabellenzeilen gefunden:', rows.length);
+        DebugLogger.log('[Modal] Tabellenzeilen gefunden:', rows.length);
 
         
        

--- a/app/planModeManager.js
+++ b/app/planModeManager.js
@@ -26,6 +26,7 @@ import { StateManager } from './stateManager.js';
 import { UIManager } from './uiManager.js';
 import { deepClone, deepEqual, deepCloneSafe} from './utils.js';
 import { HistoryManager } from './historyManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 async function commitPlanDifferences() {
 
@@ -40,7 +41,7 @@ function flattenItems(items) {
   return result;
 }
 
-  console.log("🔍 commitPlanDifferences gestartet");
+  DebugLogger.log("🔍 commitPlanDifferences gestartet");
 
   try {
     const beforeProject = StateManager.getPlanModeBackup();
@@ -59,16 +60,16 @@ function flattenItems(items) {
       return;
     }
 
-    console.log("📋 Vergleiche Liste:", listId, beforeList?.items?.length, "→", afterList?.items?.length);
+    DebugLogger.log("📋 Vergleiche Liste:", listId, beforeList?.items?.length, "→", afterList?.items?.length);
 
     let totalChanges = 0;
     const changeBuffer = [];
 
 const beforeItems = flattenItems(beforeList.items || []);
 const afterItems  = flattenItems(afterList.items || []);
-console.log("📋 beforeItems:", beforeItems.length, "afterItems:", afterItems.length);
-console.log("🔍 Beispiel beforeItem:", beforeItems[0]);
-console.log("🔍 Beispiel afterItem:", afterItems[0]);
+DebugLogger.log("📋 beforeItems:", beforeItems.length, "afterItems:", afterItems.length);
+DebugLogger.log("🔍 Beispiel beforeItem:", beforeItems[0]);
+DebugLogger.log("🔍 Beispiel afterItem:", afterItems[0]);
 
     const beforeById = Object.fromEntries(beforeItems.map(i => [i.id, i]));
     const afterById  = Object.fromEntries(afterItems.map(i => [i.id, i]));
@@ -130,7 +131,7 @@ console.log("🔍 Beispiel afterItem:", afterItems[0]);
       }
     }
 
-    console.log("🧩 erkannte Änderungen:", changeBuffer.length);
+    DebugLogger.log("🧩 erkannte Änderungen:", changeBuffer.length);
     if (changeBuffer.length === 0) {
       UIManager.showToast("Keine Änderungen erkannt.", "info");
       return;
@@ -168,7 +169,7 @@ console.log("🔍 Beispiel afterItem:", afterItems[0]);
 
     UIManager.showToast(`${totalChanges} Änderungen übernommen.`, "success");
   } catch (err) {
-    console.error("❌ Fehler in commitPlanDifferences:", err);
+    DebugLogger.error("❌ Fehler in commitPlanDifferences:", err);
   } finally {
     StateManager.setPlanModeActive(false);
     const currentList = StateManager.getCurrentList();
@@ -250,7 +251,7 @@ modus.</p>
       StateManager.clearPlanModeBackup();
 
     } catch (err) {
-      console.error("Fehler beim Beenden des Planspiels:", err);
+      DebugLogger.error("Fehler beim Beenden des Planspiels:", err);
       UIManager.showToast("Fehler beim Beenden des Planspiels", "error");
     } finally {
       // 🧩 Planspiel sauber beenden
@@ -263,7 +264,7 @@ modus.</p>
       const sw = document.getElementById("planModeSwitch");
       if (sw) sw.checked = false;
 
-      console.info("Planspielmodus vollständig beendet.");
+      DebugLogger.info("Planspielmodus vollständig beendet.");
     }
   });
 }

--- a/app/projectManager.js
+++ b/app/projectManager.js
@@ -27,6 +27,7 @@ import { StateManager } from './stateManager.js';
 import { UIManager } from './uiManager.js';
 import { Programm, compareVersions } from './programm.js';
 import { HelperManager } from './helperManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 export const ProjectManager = {
 
@@ -136,7 +137,7 @@ export const ProjectManager = {
 					const zip = new JSZip();
 					content = await zip.loadAsync(file);
 				} catch (loadError) {
-					console.error('ZIP konnte nicht geladen werden:', loadError);
+					DebugLogger.error('ZIP konnte nicht geladen werden:', loadError);
 					UIManager.showToast('Datei ist beschädigt oder kein gültiges Projekt.', 'error');
 					resolve(null);
 					return;
@@ -182,7 +183,7 @@ export const ProjectManager = {
 
                 
 				// Listen
-				console.log('Lade Listen aus ZIP');
+				DebugLogger.log('Lade Listen aus ZIP');
 
 				const lists = {};
 				const listFolder = content.folder('lists');
@@ -197,7 +198,7 @@ export const ProjectManager = {
 						}
 					});
 
-					console.log('Gefundene Listendateien:', listFiles);
+					DebugLogger.log('Gefundene Listendateien:', listFiles);
 
 					for (const filePath of listFiles) {
 						const fileEntry = listFolder.file(filePath); // Korrekt: Zugriff relativ zum Ordner
@@ -208,16 +209,16 @@ export const ProjectManager = {
 								lists[listName] = JSON.parse(listData);
 
                                 
-								console.log(`Liste geladen: ${listName}`, lists[listName]);
+								DebugLogger.log(`Liste geladen: ${listName}`, lists[listName]);
 							} catch (err) {
-								console.warn(`Fehler beim Lesen der Datei ${filePath}:`, err);
+								DebugLogger.warn(`Fehler beim Lesen der Datei ${filePath}:`, err);
 							}
 						} else {
-							console.warn('Listendatei fehlt im listFolder:', filePath);
+							DebugLogger.warn('Listendatei fehlt im listFolder:', filePath);
 						}
 					}
 				} else {
-					console.warn('Ordner "lists" nicht gefunden');
+					DebugLogger.warn('Ordner "lists" nicht gefunden');
 				}
 
 				UIManager.showToast('Listen geladen', 'success');
@@ -252,7 +253,7 @@ export const ProjectManager = {
 							const itemId = filePath.split('/').pop().replace('.json', '');
 							changelog[itemId] = JSON.parse(logData);
 						} catch (e) {
-							console.warn(`Fehler beim Lesen der Änderungsdatei ${filePath}`, e);
+							DebugLogger.warn(`Fehler beim Lesen der Änderungsdatei ${filePath}`, e);
 						}
 					}
 				}
@@ -289,7 +290,7 @@ export const ProjectManager = {
 								const snapshot = JSON.parse(raw);
 								snapshots[listId].push(snapshot);
 							} catch (e) {
-								console.warn(`Fehler beim Lesen von Snapshot ${fileName}`, e);
+								DebugLogger.warn(`Fehler beim Lesen von Snapshot ${fileName}`, e);
 							}
 						}
 					}
@@ -337,7 +338,7 @@ export const ProjectManager = {
                 };
                 StateManager.setCurrentList(null); //Reset des StateManagers. Wichtig beim laden, wenn bereits vorher ein Projekt gealden wurde
 
-				console.log('Projekt gesetzt:', project);
+				DebugLogger.log('Projekt gesetzt:', project);
                 StateManager.setCurrentProject(project);
 				UIManager.updateLists(lists);
 
@@ -345,12 +346,12 @@ export const ProjectManager = {
 
                 
                 UIManager.showToast('Projekt erfolgreich geladen', 'success');
-				console.log('StateManager.currentProject:', StateManager.getCurrentProject());
+				DebugLogger.log('StateManager.currentProject:', StateManager.getCurrentProject());
 
                 resolve(project);
 			
             } catch (error) {
-                console.error('Fehler beim Laden des Projekts:', error);
+                DebugLogger.error('Fehler beim Laden des Projekts:', error);
                 UIManager.showToast('Fehler beim Verarbeiten des Projekts', 'error');
                 resolve(null);
             }
@@ -448,7 +449,7 @@ export const ProjectManager = {
             
             UIManager.showToast('Projekt erfolgreich gespeichert', 'success');
         } catch (error) {
-            console.error('Fehler beim Speichern des Projekts:', error);
+            DebugLogger.error('Fehler beim Speichern des Projekts:', error);
             UIManager.showToast('Fehler beim Speichern', 'error');
         }
     }

--- a/app/settingsManager.js
+++ b/app/settingsManager.js
@@ -25,6 +25,7 @@
 import { StateManager } from './stateManager.js';
 import { UIManager } from './uiManager.js';
 import { AuthManager } from './AuthManager.js';
+import { DebugLogger, setDebuggingMode } from './debugLogger.js';
 
 
 async function loadDefaultConfig() {
@@ -32,7 +33,7 @@ async function loadDefaultConfig() {
         const response = await fetch('app/default_config.json');
         return await response.json();
     } catch (e) {
-        console.error('Konnte default_config.json nicht laden:', e);
+DebugLogger.error('Konnte default_config.json nicht laden:', e);
         return {};
     }
 }
@@ -45,8 +46,19 @@ export const SettingsManager = {
     defaultConfig: {},
     async init() {
         this.defaultConfig = await loadDefaultConfig();
-        console.log("DefaultConfig geladen:", this.defaultConfig); // 🔍 Debug
+        this.refreshDebuggingMode();
+        DebugLogger.log("DefaultConfig geladen:", this.defaultConfig); // 🔍 Debug
         this.loadUserSettings();
+    },
+
+    isDebuggingEnabled() {
+        const project = StateManager.getCurrentProject();
+        const value = project?.settings?.debuggingMode ?? this.defaultConfig?.debuggingMode ?? false;
+        return value === true || value === 'true';
+    },
+
+    refreshDebuggingMode() {
+        setDebuggingMode(this.isDebuggingEnabled());
     },
     async getSetting(key) {
         const project = StateManager.getCurrentProject();
@@ -81,6 +93,9 @@ async getConfigObject(key) {
             project.settings[key] = value;
             return project;
         });
+        if (key === 'debuggingMode') {
+            this.refreshDebuggingMode();
+        }
         UIManager.showToast(`Einstellung "${key}" gespeichert`, 'success');
     },
 

--- a/app/stateManager.js
+++ b/app/stateManager.js
@@ -26,6 +26,7 @@ import { HistoryManager } from './historyManager.js';
 import { TemplateManager } from './templateManager.js';
 import { UIManager } from './uiManager.js';
 import { SettingsManager } from './settingsManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 
 // ----------- Applikations-Zustand -----------
@@ -70,6 +71,7 @@ export const StateManager = {
         state.currentProject = project;
         UIManager.updateProjectInfo(project);
         TemplateManager.loadProjectTemplates(project);
+        SettingsManager.refreshDebuggingMode();
     },
 
     /**
@@ -165,10 +167,10 @@ export const StateManager = {
 
 restorePlanModeBackup() {
   if (!state.planBackup) {
-    console.warn("Kein PlanBackup zum Wiederherstellen vorhanden");
+    DebugLogger.warn("Kein PlanBackup zum Wiederherstellen vorhanden");
     return;
   }
-console.log("Restore backup:", {
+DebugLogger.log("Restore backup:", {
   hasBackup: !!state.planBackup,
   listId: state.planBackupCurrentListId,
   availableLists: Object.keys(state.planBackup?.lists || {})
@@ -214,10 +216,10 @@ console.log("Restore backup:", {
       }
     }, 50);
   } catch (err) {
-    console.error("Fehler beim UI-Refresh nach Restore:", err);
+    DebugLogger.error("Fehler beim UI-Refresh nach Restore:", err);
   }
 
-  console.info("Planspiel: Backup erfolgreich wiederhergestellt");
+  DebugLogger.info("Planspiel: Backup erfolgreich wiederhergestellt");
 },
 
 _getInternalState() {
@@ -237,7 +239,7 @@ _getInternalState() {
 
           // Schreibsperre im Planspielmodus
         if (this.isPlanModeActive()) {
-            console.warn("⏸ updateProject(): Planspielmodus aktiv – Änderungen werden nur temporär gehalten.");
+            DebugLogger.warn("⏸ updateProject(): Planspielmodus aktiv – Änderungen werden nur temporär gehalten.");
         }
 
         const project = { ...state.currentProject };

--- a/app/templateManager.js
+++ b/app/templateManager.js
@@ -26,6 +26,7 @@ import { StateManager } from './stateManager.js';
 import { generateUUID } from './utils.js'
 import { ItemManager } from './itemManager.js';
 import { UIManager, PhaseHelper} from './uiManager.js';
+import { DebugLogger } from './debugLogger.js';
 
 export const TemplateManager = {
     templates: {},
@@ -255,7 +256,7 @@ export const TemplateManager = {
                             UIManager.showToast('Vorlage erfolgreich importiert', 'success');
                             resolve(template);
                         } catch (error) {
-                            console.error('Fehler beim Parsen der Vorlage:', error);
+                            DebugLogger.error('Fehler beim Parsen der Vorlage:', error);
                             UIManager.showToast('Ungültiges Vorlagenformat', 'error');
                             resolve(null);
                         }
@@ -263,7 +264,7 @@ export const TemplateManager = {
                     
                     reader.readAsText(file);
                 } catch (error) {
-                    console.error('Fehler beim Import der Vorlage:', error);
+                    DebugLogger.error('Fehler beim Import der Vorlage:', error);
                     UIManager.showToast('Fehler beim Import', 'error');
                     resolve(null);
                 }

--- a/app/uiManager.js
+++ b/app/uiManager.js
@@ -32,6 +32,7 @@ import { renderDashboard } from './dashboard.js';
 import { HelperManager } from './helperManager.js';
 import { CommentManager } from './commentManager.js';
 import { formatGermanDate, formatDate } from './utils.js';
+import { DebugLogger } from './debugLogger.js';
 
 
 
@@ -42,7 +43,7 @@ export const PhaseHelper = {
     async init() {
         if (!_phasesCache) {
             _phasesCache = await SettingsManager.getConfigObject("lists_phase");
-            console.log("Geladene Phasen:", _phasesCache);
+            DebugLogger.log("Geladene Phasen:", _phasesCache);
         }
     },
 
@@ -262,7 +263,7 @@ export const UIManager = {
     updateLists(lists) {
         const container = document.getElementById('lists-container');
         if (!container) {
-            console.error("Listen-Container nicht gefunden");
+            DebugLogger.error("Listen-Container nicht gefunden");
             return;
         }
 
@@ -301,7 +302,7 @@ export const UIManager = {
                 this.updateSnapshotsForList(limitedLists[0].meta.id);
             }
         } catch (error) {
-            console.error("Fehler beim Aktualisieren der Listen:", error);
+            DebugLogger.error("Fehler beim Aktualisieren der Listen:", error);
             container.innerHTML = '<div class="alert alert-danger">Fehler beim Laden</div>';
         }
     },
@@ -320,7 +321,7 @@ export const UIManager = {
         listEl.className = `list-item ${isCurrent ? 'active' : ''} ${isFinalized ? 'finalized' : ''} ${list.meta?.isDeleted ? 'deleted-entry' : ''}`;
 		listEl.dataset.listId = list.meta.id;
 		
-        console.log ("Phase:",list.meta.phase)
+        DebugLogger.log ("Phase:",list.meta.phase)
         const phaseLabel = PhaseHelper.getPhaseName(list.meta.phase);
 
    
@@ -410,7 +411,7 @@ export const UIManager = {
             // Zugriff: Keys sind Strings → darum String(phaseCode)
             return phases[String(phaseCode)] || "Unbekannte Phase";
         } catch (err) {
-            console.error("Fehler beim Laden der Phasen:", err);
+            DebugLogger.error("Fehler beim Laden der Phasen:", err);
             return "Unbekannte Phase";
         }
     },*/
@@ -479,7 +480,7 @@ export const UIManager = {
 			if (existingEl) return;
 			
             container.appendChild(itemEl);
-            console.log("Rendering:", item.id, "at level", level);
+            DebugLogger.log("Rendering:", item.id, "at level", level);
 			const isHeadline = ['h1', 'h2', 'h3'].includes(item.type);
             // Kinder rendern, falls vorhanden
             if (item.children && item.children.length > 0) {
@@ -574,7 +575,7 @@ const commentCount = item.comments?.length || 0;
 
 
 
-            console.log("Details:", details)
+            DebugLogger.log("Details:", details)
 
             const dateRe = /^\d{2}\.\d{2}\.\d{4}$/;
             if (dateRe.test(userDeadline) && dateRe.test(autoDeadline)) {
@@ -587,7 +588,7 @@ const commentCount = item.comments?.length || 0;
                 }else{
                     deadlineClass = 'deadline-warning text-danger fw-bold';
                      this.criticalDeadlineCounter++; 
-                     console.log("criticalDeadlineCounter", this.criticalDeadlineCounter);
+                     DebugLogger.log("criticalDeadlineCounter", this.criticalDeadlineCounter);
                 }*/
 
                 // --- Neue Deep-Deadline prüfen ---
@@ -602,7 +603,7 @@ const commentCount = item.comments?.length || 0;
                         deadlineClass = 'deadline-warning text-danger fw-bold';
                         deadlineClassLight ='text-danger-emphasis';
                         this.criticalDeadlineCounter++;
-                        console.log("criticalDeadlineCounter (deep)", this.criticalDeadlineCounter);
+                        DebugLogger.log("criticalDeadlineCounter (deep)", this.criticalDeadlineCounter);
                     }
                 }
             }
@@ -818,7 +819,7 @@ const commentCount = item.comments?.length || 0;
         //itemEl.draggable = true;
         // Drag-Start: ID in den DataTransfer legen + visuelles Feedback
   
-        console.log("Drag?", itemEl.draggable)
+        DebugLogger.log("Drag?", itemEl.draggable)
         if (!isSnapshot) {
             // Event-Listener für Drag & Drop
             itemEl.addEventListener('dragstart', (e) => {
@@ -859,14 +860,14 @@ const commentCount = item.comments?.length || 0;
             });
             itemEl.querySelector('.comment-item').addEventListener('click', (e) => {
                 e.stopPropagation();
-                console.log("🕒 comment für:", item.id);
+                DebugLogger.log("🕒 comment für:", item.id);
                 CommentManager.showCommentModal(item.id);
             });
         }
 
 		itemEl.querySelector('.history-item').addEventListener('click', (e) => {
 			e.stopPropagation();
-			console.log("🕒 Verlauf für:", item.id);
+			DebugLogger.log("🕒 Verlauf für:", item.id);
 			HistoryManager.showItemHistory(item.id);
 		});
 
@@ -1388,7 +1389,7 @@ const commentCount = item.comments?.length || 0;
             const deadlineInput = document.getElementById('item-deadline');
             const deadlineRaw = deadlineInput.value.trim();
             
-            console.log('Editor DateMode:', CONFIG_dateOnly)
+            DebugLogger.log('Editor DateMode:', CONFIG_dateOnly)
 
              if (CONFIG_dateOnly === "true") {
             const dateRegex = /^\d{2}\.\d{2}\.\d{4}$/;
@@ -1712,7 +1713,7 @@ const commentCount = item.comments?.length || 0;
                         ${allP
                             .filter(p => !p.isDeleted)  
                             .map(p => {
-                            console.log('Item:', p);
+                            DebugLogger.log('Item:', p);
                             const parents = resolveParentHeadlines(p, allItemsFlat);
   
                             //const parentPath = parents.map(par => `${par.type.toUpperCase()}: ${par.data.report_topic || ''}`).join(' > ');

--- a/app/utils.js
+++ b/app/utils.js
@@ -21,6 +21,7 @@
  * Hinweis:
  * - Externe Bibliotheken behalten ihre eigenen Lizenzen.
  */
+import { DebugLogger } from './debugLogger.js';
 
 // utils.js
 
@@ -58,7 +59,7 @@
         try {
         return structuredClone(obj);
         } catch (e) {
-        console.warn("structuredClone fehlgeschlagen, fallback auf JSON:", e);
+        DebugLogger.warn("structuredClone fehlgeschlagen, fallback auf JSON:", e);
         }
     }
     return JSON.parse(JSON.stringify(obj));


### PR DESCRIPTION
### Motivation
- Centralize and control debug/log output across the app so logs can be toggled without changing many `console.*` calls. 
- Provide a project-level / default switch for enabling debug output via configuration.

### Description
- Added a new `debugLogger.js` module with `DebugLogger` (methods `log/info/warn/error/debug`) and `setDebuggingMode` to enable/disable logging. 
- Replaced scattered `console.log/warn/error/info/debug` calls with `DebugLogger.*` across multiple managers and utilities (e.g. `app.js`, `comparisonManager.js`, `exportManager2.js`, `ganttManager.js`, `helperManager.js`, `historyManager.js`, `holidayManager.js`, `itemManager.js`, `listManager.js`, `planModeManager.js`, `projectManager.js`, `settingsManager.js`, `stateManager.js`, `templateManager.js`, `uiManager.js`, `utils.js`, `exportExcelManager.js`).
- Integrated debug mode into settings flow by adding `debuggingMode` to `app/default_config.json`, exposing `SettingsManager.isDebuggingEnabled()` and `SettingsManager.refreshDebuggingMode()` and wiring `setDebuggingMode` to project/default settings so the logger follows the configured mode; `StateManager.setCurrentProject` triggers a refresh of debugging mode.
- Added `debugConsole.js` as a deprecated no-op shim and updated imports/usages where appropriate.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9eb1b278883288db931f5b78190e0)