### PR TITLE
Add password policy, bot-protection, input validation and safe logging; update registration flow and assets

### DIFF
--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -54,6 +54,175 @@ $_SESSION['LAST_ACTIVITY'] = time();
 const USERS_FILE = __DIR__ . '/../data/users.json';
 const AUTH_LOG   = __DIR__ . '/../data/auth.log';
 
+
+const MAX_LOGIN_LENGTH = 190;
+const MAX_NAME_LENGTH = 100;
+
+function clean_log_fragment(string $value): string {
+  $value = str_replace(["\r", "\n", "\t"], ' ', $value);
+  return trim($value);
+}
+
+function normalize_userid(string $userid): string {
+  return trim($userid);
+}
+
+function validate_userid_or_fail(string $userid): string {
+  $userid = normalize_userid($userid);
+  if ($userid === '' || strlen($userid) > 64) {
+    json_err('Ungültige UserID', 422);
+  }
+  if (!preg_match('/^[A-Za-z0-9._-]+$/', $userid)) {
+    json_err('Ungültige UserID', 422);
+  }
+  return $userid;
+}
+
+function validate_email_or_fail(string $email): string {
+  $email = trim($email);
+  if ($email === '' || strlen($email) > 190 || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    json_err('Ungültige E-Mail', 422);
+  }
+  return $email;
+}
+
+function validate_name_or_fail(string $name, string $label): string {
+  $name = trim($name);
+  if ($name === '' || strlen($name) > MAX_NAME_LENGTH) {
+    json_err("Ungültiger {$label}", 422);
+  }
+  return $name;
+}
+
+function default_password_policy(): array {
+  return [
+    'min_length' => 10,
+    'max_length' => 128,
+    'require_uppercase' => false,
+    'require_lowercase' => false,
+    'require_number' => false,
+    'require_special' => false,
+  ];
+}
+
+function default_bot_protection(): array {
+  return [
+    'enabled' => false,
+    'min_form_fill_seconds' => 3,
+    'honeypot_field' => 'company_website',
+  ];
+}
+
+function sanitize_bot_protection(array $bot): array {
+  $defaults = default_bot_protection();
+
+  $enabled = (bool)($bot['enabled'] ?? $defaults['enabled']);
+  $minSeconds = (int)($bot['min_form_fill_seconds'] ?? $defaults['min_form_fill_seconds']);
+  if ($minSeconds < 0 || $minSeconds > 120) {
+    json_err('bot_protection.min_form_fill_seconds muss zwischen 0 und 120 liegen', 422);
+  }
+
+  $honeypot = trim((string)($bot['honeypot_field'] ?? $defaults['honeypot_field']));
+  if ($honeypot === '' || strlen($honeypot) > 64 || !preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $honeypot)) {
+    json_err('bot_protection.honeypot_field ist ungültig', 422);
+  }
+
+  return [
+    'enabled' => $enabled,
+    'min_form_fill_seconds' => $minSeconds,
+    'honeypot_field' => $honeypot,
+  ];
+}
+
+function get_bot_protection_settings(): array {
+  $settings = load_app_settings();
+  $bot = $settings['bot_protection'] ?? [];
+  if (!is_array($bot)) return default_bot_protection();
+
+  $defaults = default_bot_protection();
+  $enabled = (bool)($bot['enabled'] ?? $defaults['enabled']);
+  $minSeconds = (int)($bot['min_form_fill_seconds'] ?? $defaults['min_form_fill_seconds']);
+  $honeypot = trim((string)($bot['honeypot_field'] ?? $defaults['honeypot_field']));
+
+  if ($minSeconds < 0 || $minSeconds > 120) $minSeconds = $defaults['min_form_fill_seconds'];
+  if ($honeypot === '' || strlen($honeypot) > 64 || !preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/', $honeypot)) {
+    $honeypot = $defaults['honeypot_field'];
+  }
+
+  return [
+    'enabled' => $enabled,
+    'min_form_fill_seconds' => $minSeconds,
+    'honeypot_field' => $honeypot,
+  ];
+}
+
+function sanitize_password_policy(array $policy): array {
+  $defaults = default_password_policy();
+
+  $min = (int)($policy['min_length'] ?? $defaults['min_length']);
+  $max = (int)($policy['max_length'] ?? $defaults['max_length']);
+  if ($min < 6 || $min > 256) json_err('password_policy.min_length muss zwischen 6 und 256 liegen', 422);
+  if ($max < $min || $max > 512) json_err('password_policy.max_length ist ungültig', 422);
+
+  return [
+    'min_length' => $min,
+    'max_length' => $max,
+    'require_uppercase' => (bool)($policy['require_uppercase'] ?? $defaults['require_uppercase']),
+    'require_lowercase' => (bool)($policy['require_lowercase'] ?? $defaults['require_lowercase']),
+    'require_number' => (bool)($policy['require_number'] ?? $defaults['require_number']),
+    'require_special' => (bool)($policy['require_special'] ?? $defaults['require_special']),
+  ];
+}
+
+function get_password_policy(): array {
+  $settings = load_app_settings();
+  $policyRaw = $settings['password_policy'] ?? [];
+  if (!is_array($policyRaw)) {
+    return default_password_policy();
+  }
+
+  $defaults = default_password_policy();
+
+  $min = (int)($policyRaw['min_length'] ?? $defaults['min_length']);
+  $max = (int)($policyRaw['max_length'] ?? $defaults['max_length']);
+
+  if ($min < 6 || $min > 256) $min = $defaults['min_length'];
+  if ($max < $min || $max > 512) $max = max($min, $defaults['max_length']);
+
+  return [
+    'min_length' => $min,
+    'max_length' => $max,
+    'require_uppercase' => (bool)($policyRaw['require_uppercase'] ?? $defaults['require_uppercase']),
+    'require_lowercase' => (bool)($policyRaw['require_lowercase'] ?? $defaults['require_lowercase']),
+    'require_number' => (bool)($policyRaw['require_number'] ?? $defaults['require_number']),
+    'require_special' => (bool)($policyRaw['require_special'] ?? $defaults['require_special']),
+  ];
+}
+
+function validate_password_or_fail(string $password, string $message = 'Passwort zu schwach'): string {
+  $policy = get_password_policy();
+  $length = strlen($password);
+
+  if ($length < $policy['min_length'] || $length > $policy['max_length']) {
+    json_err($message, 422);
+  }
+
+  if ($policy['require_uppercase'] && !preg_match('/[A-Z]/', $password)) {
+    json_err($message, 422);
+  }
+  if ($policy['require_lowercase'] && !preg_match('/[a-z]/', $password)) {
+    json_err($message, 422);
+  }
+  if ($policy['require_number'] && !preg_match('/[0-9]/', $password)) {
+    json_err($message, 422);
+  }
+  if ($policy['require_special'] && !preg_match('/[^A-Za-z0-9]/', $password)) {
+    json_err($message, 422);
+  }
+
+  return $password;
+}
+
 function json_ok($data = [], int $code = 200) {
   http_response_code($code);
   echo json_encode(['ok' => true, 'data' => $data], JSON_UNESCAPED_UNICODE);
@@ -127,7 +296,8 @@ function client_ip(): string {
   return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
 }
 function auth_log(string $line): void {
-  @file_put_contents(AUTH_LOG, sprintf("[%s] %s %s\n", now_iso(), client_ip(), $line), FILE_APPEND|LOCK_EX);
+  $safeLine = clean_log_fragment($line);
+  @file_put_contents(AUTH_LOG, sprintf("[%s] %s %s\n", now_iso(), client_ip(), $safeLine), FILE_APPEND|LOCK_EX);
   @chmod(AUTH_LOG, 0600);
 }
 
@@ -194,6 +364,8 @@ function settings_registry(): array {
       'default' => [
         'registration_mode' => 'approval',
         'departments' => [],
+        'password_policy' => default_password_policy(),
+        'bot_protection' => default_bot_protection(),
       ],
     ],
     'loptastic_defaults' => [
@@ -241,9 +413,21 @@ function validate_settings_payload(string $key, array $payload): array {
       }
     }
 
+    $passwordPolicyRaw = $payload['password_policy'] ?? [];
+    if (!is_array($passwordPolicyRaw)) {
+      json_err('password_policy muss ein Objekt sein', 422);
+    }
+
+    $botProtectionRaw = $payload['bot_protection'] ?? [];
+    if (!is_array($botProtectionRaw)) {
+      json_err('bot_protection muss ein Objekt sein', 422);
+    }
+
     return [
       'registration_mode' => $mode,
       'departments' => array_values(array_unique($cleanDepartments)),
+      'password_policy' => sanitize_password_policy($passwordPolicyRaw),
+      'bot_protection' => sanitize_bot_protection($botProtectionRaw),
     ];
   }
 

--- a/api/auth/change_password.php
+++ b/api/auth/change_password.php
@@ -32,6 +32,7 @@ $old = (string)($in['old_password'] ?? '');
 $new = (string)($in['new_password'] ?? '');
 
 if ($old==='' || $new==='') json_err('Felder fehlen', 422);
+validate_password_or_fail($new, 'Neues Passwort erfüllt die Vorgaben nicht');
 
 $users = load_users();
 foreach ($users as &$u) {

--- a/api/auth/login.php
+++ b/api/auth/login.php
@@ -32,6 +32,34 @@ $pass  = (string)($body['password'] ?? '');
 if ($login === '' || $pass === '') json_err('Login und Passwort erforderlich', 422);
 if (strlen($login) > MAX_LOGIN_LENGTH || strlen($pass) > 1024) json_err('Ungültige Zugangsdaten', 401);
 
+
+$botProtection = get_bot_protection_settings();
+if (!empty($botProtection['enabled'])) {
+  $bot = $body['bot_protection'] ?? null;
+  if (!is_array($bot)) {
+    json_err('Login konnte nicht verifiziert werden', 422);
+  }
+
+  $token = (string)($bot['token'] ?? '');
+  $honeypot = trim((string)($bot['honeypot'] ?? ''));
+  $expectedToken = (string)($_SESSION['login_bot_token'] ?? '');
+  $issuedAt = (int)($_SESSION['login_bot_issued_at'] ?? 0);
+
+  if ($expectedToken === '' || $token === '' || !hash_equals($expectedToken, $token)) {
+    json_err('Login konnte nicht verifiziert werden', 422);
+  }
+
+  if ($honeypot !== '') {
+    json_err('Login konnte nicht verifiziert werden', 422);
+  }
+
+  if ($issuedAt <= 0 || (time() - $issuedAt) < (int)$botProtection['min_form_fill_seconds']) {
+    json_err('Login konnte nicht verifiziert werden', 422);
+  }
+
+  unset($_SESSION['login_bot_token'], $_SESSION['login_bot_issued_at']);
+}
+
 $users = load_users();
 $u = user_by_login($login, $users);
 

--- a/api/auth/login.php
+++ b/api/auth/login.php
@@ -30,13 +30,16 @@ $login = trim((string)($body['login'] ?? ''));
 $pass  = (string)($body['password'] ?? '');
 
 if ($login === '' || $pass === '') json_err('Login und Passwort erforderlich', 422);
+if (strlen($login) > MAX_LOGIN_LENGTH || strlen($pass) > 1024) json_err('Ungültige Zugangsdaten', 401);
 
 $users = load_users();
 $u = user_by_login($login, $users);
 
 // generische Antwort, um User-Enumeration zu erschweren
 if (!$u) {
-  auth_log("LOGIN FAIL user=UNKNOWN login={$login}");
+  // Timing-Angleich für unbekannte Accounts
+  password_verify($pass, '$2y$10$wUg0Uy4vA5YxK4fEmNfST.9f7QFq7fNfX6aZ0f5BP6vJm6D2Y9y4m');
+  auth_log('LOGIN FAIL user=UNKNOWN login=' . clean_log_fragment($login));
   json_err('Ungültige Zugangsdaten', 401);
 }
 if (!empty($u['locked'])) json_err('Account gesperrt', 403);
@@ -47,7 +50,7 @@ if (!password_verify($pass, $u['password_hash'] ?? '')) {
   // persist fail
   foreach ($users as &$ref) { if ($ref['id'] === $u['id']) { $ref = $u; break; } }
   save_users($users);
-  auth_log("LOGIN FAIL userid={$u['userid']} id={$u['id']}");
+  auth_log('LOGIN FAIL userid=' . clean_log_fragment((string)$u['userid']) . ' id=' . clean_log_fragment((string)$u['id']));
   json_err('Ungültige Zugangsdaten', 401);
 }
 
@@ -58,7 +61,7 @@ on_success_login($u);
 foreach ($users as &$ref) { if ($ref['id'] === $u['id']) { $ref = $u; break; } }
 save_users($users);
 
-auth_log("LOGIN OK userid={$u['userid']} id={$u['id']}");
+auth_log('LOGIN OK userid=' . clean_log_fragment((string)$u['userid']) . ' id=' . clean_log_fragment((string)$u['id']));
 
 json_ok([
   'csrf' => csrf_token(),

--- a/api/auth/register.php
+++ b/api/auth/register.php
@@ -35,16 +35,40 @@ $departments = $settings['departments'] ?? [];
 
 
 $in = json_decode(file_get_contents('php://input'), true) ?? [];
-$first = trim((string)($in['first_name'] ?? ''));
-$last  = trim((string)($in['last_name'] ?? ''));
-$email = trim((string)($in['email'] ?? ''));
-$userid= trim((string)($in['userid'] ?? ''));
-$pass  = (string)($in['password'] ?? '');
+$first = validate_name_or_fail((string)($in['first_name'] ?? ''), 'Vorname');
+$last  = validate_name_or_fail((string)($in['last_name'] ?? ''), 'Nachname');
+$email = validate_email_or_fail((string)($in['email'] ?? ''));
+$userid= validate_userid_or_fail((string)($in['userid'] ?? ''));
+$pass  = validate_password_or_fail((string)($in['password'] ?? ''), 'Passwort erfüllt die Vorgaben nicht');
 $dept = trim((string)($in['department'] ?? ''));
 
-if ($first===''||$last===''||$userid===''||$email===''||$pass==='') {
-    json_err('Alle Felder erforderlich', 422);
+$botProtection = get_bot_protection_settings();
+if (!empty($botProtection['enabled'])) {
+    $bot = $in['bot_protection'] ?? null;
+    if (!is_array($bot)) {
+        json_err('Registrierung konnte nicht verifiziert werden', 422);
+    }
+
+    $token = (string)($bot['token'] ?? '');
+    $honeypot = trim((string)($bot['honeypot'] ?? ''));
+    $expectedToken = (string)($_SESSION['register_bot_token'] ?? '');
+    $issuedAt = (int)($_SESSION['register_bot_issued_at'] ?? 0);
+
+    if ($expectedToken === '' || $token === '' || !hash_equals($expectedToken, $token)) {
+        json_err('Registrierung konnte nicht verifiziert werden', 422);
+    }
+
+    if ($honeypot !== '') {
+        json_err('Registrierung konnte nicht verifiziert werden', 422);
+    }
+
+    if ($issuedAt <= 0 || (time() - $issuedAt) < (int)$botProtection['min_form_fill_seconds']) {
+        json_err('Registrierung konnte nicht verifiziert werden', 422);
+    }
+
+    unset($_SESSION['register_bot_token'], $_SESSION['register_bot_issued_at']);
 }
+
 if ($dept !== '' && !in_array($dept, $departments, true)) {
     json_err('Ungültige Abteilung', 422);
 }

--- a/api/public/settings/login.php
+++ b/api/public/settings/login.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/../../_bootstrap.php';
+
+$botProtection = get_bot_protection_settings();
+$botToken = null;
+
+if (!empty($botProtection['enabled'])) {
+  $botToken = bin2hex(random_bytes(16));
+  $_SESSION['login_bot_token'] = $botToken;
+  $_SESSION['login_bot_issued_at'] = time();
+}
+
+json_ok([
+  'bot_protection' => $botProtection,
+  'bot_token' => $botToken,
+]);

--- a/api/public/settings/registration.php
+++ b/api/public/settings/registration.php
@@ -5,7 +5,19 @@ $section = get_settings_section('registration');
 if ($section === null) json_err('Settings nicht gefunden', 404);
 
 $data = $section['data'];
+$botProtection = get_bot_protection_settings();
+$botToken = null;
+
+if (!empty($botProtection['enabled'])) {
+  $botToken = bin2hex(random_bytes(16));
+  $_SESSION['register_bot_token'] = $botToken;
+  $_SESSION['register_bot_issued_at'] = time();
+}
+
 json_ok([
   'registration_mode' => $data['registration_mode'] ?? 'approval',
   'departments' => $data['departments'] ?? [],
+  'password_policy' => $data['password_policy'] ?? default_password_policy(),
+  'bot_protection' => $botProtection,
+  'bot_token' => $botToken,
 ]);

--- a/api/users/create.php
+++ b/api/users/create.php
@@ -5,11 +5,11 @@ require_admin();
 verify_csrf();
 
 $in = json_decode(file_get_contents('php://input'), true) ?? [];
-$first = trim((string)($in['first_name'] ?? ''));
-$last  = trim((string)($in['last_name'] ?? ''));
-$userid= trim((string)($in['userid'] ?? ''));
-$email = trim((string)($in['email'] ?? ''));
-$pass  = (string)($in['password'] ?? '');
+$first = validate_name_or_fail((string)($in['first_name'] ?? ''), 'Vorname');
+$last  = validate_name_or_fail((string)($in['last_name'] ?? ''), 'Nachname');
+$userid= validate_userid_or_fail((string)($in['userid'] ?? ''));
+$email = validate_email_or_fail((string)($in['email'] ?? ''));
+$pass  = validate_password_or_fail((string)($in['password'] ?? ''), 'Passwort erfüllt die Vorgaben nicht');
 $dept = trim((string)($in['department'] ?? ''));
 $role  = ((string)($in['role'] ?? 'user')) === 'admin' ? 'admin' : 'user';
 $settings = load_app_settings();
@@ -17,8 +17,6 @@ $departments = $settings['departments'] ?? [];
 if ($dept !== '' && !in_array($dept, $departments, true)) {
     json_err('Ungültige Abteilung', 422);
 }
-
-if ($first===''||$last===''||$userid===''||$email===''||$pass==='') json_err('Felder unvollständig', 422);
 
 $users = load_users();
 if (user_by_login($userid, $users) || user_by_login($email, $users)) json_err('UserID oder E-Mail bereits vergeben', 409);
@@ -44,5 +42,5 @@ $users[] = [
 ];
 
 save_users($users);
-auth_log("USER CREATE id=$id userid=$userid role=$role");
+auth_log('USER CREATE id=' . clean_log_fragment($id) . ' userid=' . clean_log_fragment($userid) . ' role=' . clean_log_fragment($role));
 json_ok(['id' => $id], 201);

--- a/api/users/set_password.php
+++ b/api/users/set_password.php
@@ -8,6 +8,7 @@ $in = json_decode(file_get_contents('php://input'), true) ?? [];
 $id = (string)($in['id'] ?? '');
 $new = (string)($in['password'] ?? '');
 if ($id==='' || $new==='') json_err('ID/Passwort fehlt', 422);
+validate_password_or_fail($new, 'Passwort erfüllt die Vorgaben nicht');
 
 $users = load_users();
 $found = false;

--- a/assets/login.js
+++ b/assets/login.js
@@ -4,7 +4,60 @@
   const msg  = document.getElementById('msg');
   const btn  = document.getElementById('btn-login');
 
+  let botProtection = {
+    enabled: false,
+    honeypot_field: 'company_website',
+  };
+  let botToken = null;
+
   function setMsg(t) { msg.textContent = t || ''; }
+
+  function ensureHoneypotField() {
+    if (!form) return;
+
+    const existing = document.getElementById('login-bot-honeypot-field');
+    if (existing) existing.remove();
+
+    if (!botProtection?.enabled) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.id = 'login-bot-honeypot-field';
+    wrapper.style.position = 'absolute';
+    wrapper.style.left = '-9999px';
+    wrapper.style.width = '1px';
+    wrapper.style.height = '1px';
+    wrapper.style.overflow = 'hidden';
+
+    const label = document.createElement('label');
+    label.setAttribute('for', 'login-hp-input');
+    label.textContent = 'Dieses Feld leer lassen';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'login-hp-input';
+    input.name = botProtection.honeypot_field || 'company_website';
+    input.autocomplete = 'off';
+    input.tabIndex = -1;
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    form.appendChild(wrapper);
+  }
+
+  async function loadLoginSettings() {
+    try {
+      const res = await fetch('/loptastic/api/public/settings/login.php', { credentials: 'include' });
+      const payload = await res.json();
+      const data = payload?.data || {};
+      botProtection = data.bot_protection || botProtection;
+      botToken = data.bot_token || null;
+      ensureHoneypotField();
+    } catch (err) {
+      console.error('Login-Settings konnten nicht geladen werden', err);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', loadLoginSettings);
 
   form?.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -13,10 +66,18 @@
     try {
       const login = document.getElementById('login').value.trim();
       const password = document.getElementById('password').value;
+      const honeypot = document.getElementById('login-hp-input')?.value || '';
       const res = await fetch('/loptastic/api/auth/login.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ login, password }),
+        body: JSON.stringify({
+          login,
+          password,
+          bot_protection: {
+            token: botToken,
+            honeypot,
+          },
+        }),
         credentials: 'include'
       });
       const data = await res.json();

--- a/assets/register.js
+++ b/assets/register.js
@@ -1,58 +1,118 @@
-async function loadDepartments() {
+let registrationSettings = {
+  departments: [],
+  botProtection: {
+    enabled: false,
+    honeypot_field: 'company_website',
+  },
+  botToken: null,
+};
+
+function renderDepartments(departments) {
+  const sel = document.getElementById('department');
+  if (!sel) return;
+  sel.innerHTML = '';
+  departments.forEach(d => {
+    const opt = document.createElement('option');
+    opt.value = d;
+    opt.textContent = d;
+    sel.appendChild(opt);
+  });
+}
+
+function ensureHoneypotField(botProtection) {
+  const form = document.getElementById('register-form');
+  if (!form) return;
+
+  const existing = document.getElementById('bot-honeypot-field');
+  if (existing) existing.remove();
+
+  if (!botProtection?.enabled) return;
+
+  const wrapper = document.createElement('div');
+  wrapper.id = 'bot-honeypot-field';
+  wrapper.style.position = 'absolute';
+  wrapper.style.left = '-9999px';
+  wrapper.style.width = '1px';
+  wrapper.style.height = '1px';
+  wrapper.style.overflow = 'hidden';
+
+  const label = document.createElement('label');
+  label.setAttribute('for', 'hp-input');
+  label.textContent = 'Dieses Feld leer lassen';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.id = 'hp-input';
+  input.name = botProtection.honeypot_field || 'company_website';
+  input.autocomplete = 'off';
+  input.tabIndex = -1;
+
+  wrapper.appendChild(label);
+  wrapper.appendChild(input);
+  form.appendChild(wrapper);
+}
+
+async function loadRegistrationSettings() {
   try {
-    const res = await fetch('/loptastic/api/public/settings/registration.php'); // öffentlich lesbar?
+    const res = await fetch('/loptastic/api/public/settings/registration.php');
     const payload = await res.json();
-    const departments = payload?.data?.departments || [];
-    const sel = document.getElementById('department');
-    departments.forEach(d => {
-      const opt = document.createElement('option');
-      opt.value = d;
-      opt.textContent = d;
-      sel.appendChild(opt);
-    });
+
+    const data = payload?.data || {};
+    registrationSettings.departments = data.departments || [];
+    registrationSettings.botProtection = data.bot_protection || registrationSettings.botProtection;
+    registrationSettings.botToken = data.bot_token || null;
+
+    renderDepartments(registrationSettings.departments);
+    ensureHoneypotField(registrationSettings.botProtection);
   } catch (e) {
-    console.error("Abteilungen konnten nicht geladen werden", e);
+    console.error('Registrierungs-Settings konnten nicht geladen werden', e);
   }
 }
 
-document.addEventListener('DOMContentLoaded', loadDepartments);
+document.addEventListener('DOMContentLoaded', loadRegistrationSettings);
 
 document.getElementById('register-form')?.addEventListener('submit', async (e) => {
   e.preventDefault();
   const msg = document.getElementById('msg');
 
+  const honeypotValue = document.getElementById('hp-input')?.value || '';
+
   const body = {
     first_name: document.getElementById('first').value.trim(),
-    last_name:  document.getElementById('last').value.trim(),
-    userid:     document.getElementById('userid').value.trim(),
-    email:      document.getElementById('email').value.trim(),
-    password:   document.getElementById('pass').value,
-    department: document.getElementById('department').value  // NEU
+    last_name: document.getElementById('last').value.trim(),
+    userid: document.getElementById('userid').value.trim(),
+    email: document.getElementById('email').value.trim(),
+    password: document.getElementById('pass').value,
+    department: document.getElementById('department').value,
+    bot_protection: {
+      token: registrationSettings.botToken,
+      honeypot: honeypotValue,
+    },
   };
 
   const pass2 = document.getElementById('pass2').value;
   if (body.password !== pass2) {
-    msg.textContent = "Passwörter stimmen nicht überein.";
+    msg.textContent = 'Passwörter stimmen nicht überein.';
     return;
   }
 
- try {
+  try {
     const res = await fetch('/loptastic/api/auth/register.php', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify(body)
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
     });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'Fehler bei Registrierung');
 
     if (j.data.pending) {
-      msg.textContent = "Registrierung erfolgreich! Dein Account muss vom Admin freigegeben werden.";
+      msg.textContent = 'Registrierung erfolgreich! Dein Account muss vom Admin freigegeben werden.';
     } else {
-      msg.textContent = "Registrierung erfolgreich! Du kannst dich jetzt einloggen.";
+      msg.textContent = 'Registrierung erfolgreich! Du kannst dich jetzt einloggen.';
     }
-    msg.style.color = "green";
+    msg.style.color = 'green';
   } catch (err) {
     msg.textContent = err.message;
-    msg.style.color = "red";
+    msg.style.color = 'red';
   }
 });

--- a/assets/user-admin.js
+++ b/assets/user-admin.js
@@ -39,26 +39,51 @@ async function loadUsers() {
 
   j.data.users.forEach(u=>{
     const tr = document.createElement('tr');
-const status = u.pending 
-  ? '<span class="badge locked">wartet auf Freigabe</span>' 
-  : (u.locked ? '<span class="badge locked">gesperrt</span>' : 'aktiv');
 
-tr.innerHTML = `
-  <td>${u.first_name} ${u.last_name}</td>
-  <td>${u.userid}<br><small>${u.email}</small></td>
-  <td><span class="badge ${u.role}">${u.role}</span></td>
-  <td>${status}</td>
-  <td>${u.department ?? '—'}</td>
-  <td>${u.last_login_at ?? '—'}</td>
-  <td>${u.created_at ?? '—'}</td>
-  <td>
-    ${u.pending 
-      ? `<button onclick="approveUser('${u.id}')">Freigeben</button>`
-      : `<button onclick="toggleLock('${u.id}', ${!u.locked})">Sperren/Entsperren</button>`
+    const fullName = `${u.first_name ?? ''} ${u.last_name ?? ''}`.trim();
+    tr.appendChild(el('td', {}, [fullName || '—']));
+
+    const userCell = document.createElement('td');
+    userCell.appendChild(txt(u.userid ?? '—'));
+    userCell.appendChild(document.createElement('br'));
+    userCell.appendChild(el('small', {}, [u.email ?? '—']));
+    tr.appendChild(userCell);
+
+    const roleBadge = el('span', { class: `badge ${u.role === 'admin' ? 'admin' : 'user'}` }, [u.role ?? 'user']);
+    tr.appendChild(el('td', {}, [roleBadge]));
+
+    const statusCell = document.createElement('td');
+    if (u.pending) {
+      statusCell.appendChild(el('span', { class: 'badge locked' }, ['wartet auf Freigabe']));
+    } else {
+      statusCell.appendChild(txt(u.locked ? 'gesperrt' : 'aktiv'));
     }
-    <button onclick="resetPass('${u.id}')">Passwort setzen</button>
-    <button onclick="delUser('${u.id}')">Löschen</button>
-  </td>`;
+    tr.appendChild(statusCell);
+
+    tr.appendChild(el('td', {}, [u.department || '—']));
+    tr.appendChild(el('td', {}, [u.last_login_at ?? '—']));
+    tr.appendChild(el('td', {}, [u.created_at ?? '—']));
+
+    const actionsCell = document.createElement('td');
+    if (u.pending) {
+      const approveBtn = el('button', {}, ['Freigeben']);
+      approveBtn.addEventListener('click', () => approveUser(u.id));
+      actionsCell.appendChild(approveBtn);
+    } else {
+      const toggleBtn = el('button', {}, ['Sperren/Entsperren']);
+      toggleBtn.addEventListener('click', () => toggleLock(u.id, !u.locked));
+      actionsCell.appendChild(toggleBtn);
+    }
+
+    const resetBtn = el('button', {}, ['Passwort setzen']);
+    resetBtn.addEventListener('click', () => resetPass(u.id));
+    actionsCell.appendChild(resetBtn);
+
+    const deleteBtn = el('button', {}, ['Löschen']);
+    deleteBtn.addEventListener('click', () => delUser(u.id));
+    actionsCell.appendChild(deleteBtn);
+
+    tr.appendChild(actionsCell);
     tb.appendChild(tr);
   });
 }

--- a/data/settings.template.json
+++ b/data/settings.template.json
@@ -1,1 +1,17 @@
-
+{
+  "registration_mode": "approval",
+  "departments": [],
+  "password_policy": {
+    "min_length": 10,
+    "max_length": 128,
+    "require_uppercase": false,
+    "require_lowercase": false,
+    "require_number": false,
+    "require_special": false
+  },
+  "bot_protection": {
+    "enabled": false,
+    "min_form_fill_seconds": 3,
+    "honeypot_field": "company_website"
+  }
+}


### PR DESCRIPTION
### Motivation

- Harden authentication and registration by centralizing validation and password policy enforcement to reduce weak passwords and invalid input.
- Add lightweight bot protection for public registration to mitigate automated signups while keeping the default disabled.
- Prevent log-injection and user-enumeration via safer auth logging and timing-equalized unknown-login handling.
- Provide sane defaults in settings and expose password/bot policy to the client for better UX.

### Description

- Introduced constants and helper functions in `_bootstrap.php` for input cleaning (`clean_log_fragment`), normalization and validation (`validate_userid_or_fail`, `validate_email_or_fail`, `validate_name_or_fail`) and safe logging usage (`clean_log_fragment`).
- Added password policy management (`default_password_policy`, `sanitize_password_policy`, `get_password_policy`, `validate_password_or_fail`) and bot-protection support (`default_bot_protection`, `sanitize_bot_protection`, `get_bot_protection_settings`) with settings persistence and validation integrated into `settings_registry` and `validate_settings_payload`.
- Enforced password validation in `change_password.php`, `users/set_password.php`, `users/create.php`, and `auth/register.php`, added login input length checks in `auth/login.php`, and hardened unknown-login handling by performing a dummy `password_verify` and sanitizing log fragments.
- Extended public registration endpoint `api/public/settings/registration.php` to return `password_policy`, `bot_protection` and a per-session `bot_token` when enabled, and updated `data/settings.template.json` to include the new default structures.
- Updated client assets (`assets/register.js` and `assets/user-admin.js`) to load/render registration settings, implement honeypot field and token submission for bot protection, and modernized user-admin DOM building and action wiring.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdd1242f08328861d7d89236968b9)