### PR TITLE
Add forced password-change flow and admin-enforced password reset

### DIFF
--- a/api/auth/change_password.php
+++ b/api/auth/change_password.php
@@ -38,6 +38,7 @@ foreach ($users as &$u) {
   if ($u['id'] === $user['id']) {
     if (!password_verify($old, $u['password_hash'] ?? '')) json_err('Altes Passwort falsch', 401);
     $u['password_hash'] = password_hash($new, PASSWORD_DEFAULT);
+    $u['force_password_change'] = false;
     $u['updated_at'] = now_iso();
     save_users($users);
     auth_log("PASS CHANGE uid={$u['id']}");

--- a/api/auth/login.php
+++ b/api/auth/login.php
@@ -69,6 +69,7 @@ json_ok([
     'first_name' => $u['first_name'],
     'last_name'  => $u['last_name'],
     'role'       => $u['role'] ?? 'user',
+    'force_password_change' => $u['force_password_change'] ?? false,
     'last_login_at' => $u['last_login_at'] ?? null,
     'created_at' => $u['created_at'] ?? null,
   ]

--- a/api/auth/me.php
+++ b/api/auth/me.php
@@ -43,6 +43,7 @@ foreach ($users as $u) {
         'last_name' => $u['last_name'],
         'department' => $u['department'] ?? null,
         'role' => $u['role'] ?? 'user',
+        'force_password_change' => $u['force_password_change'] ?? false,
         'last_login_at' => $u['last_login_at'] ?? null,
         'created_at' => $u['created_at'] ?? null
       ]

--- a/api/users/create.php
+++ b/api/users/create.php
@@ -38,6 +38,7 @@ $users[] = [
   'created_at' => $now,
   'updated_at' => $now,
   'last_login_at' => null,
+  'force_password_change' => true,
   'password_hash' => password_hash($pass, PASSWORD_DEFAULT),
   'failed_login_attempts' => 0,
   'locked_until' => null

--- a/api/users/list.php
+++ b/api/users/list.php
@@ -5,7 +5,8 @@ require_admin();
 
 $users = load_users();
 foreach ($users as &$u) {
-    $u['pending'] = $u['pending'] ?? false;
+  $u['pending'] = $u['pending'] ?? false;
+  $u['force_password_change'] = $u['force_password_change'] ?? false;
   unset($u['password_hash'], $u['failed_login_attempts'], $u['locked_until']);
 }
 json_ok(['users' => $users]);

--- a/api/users/set_password.php
+++ b/api/users/set_password.php
@@ -15,6 +15,7 @@ foreach ($users as &$u) {
   if ($u['id'] === $id) {
     $found = true;
     $u['password_hash'] = password_hash($new, PASSWORD_DEFAULT);
+    $u['force_password_change'] = true;
     $u['updated_at'] = now_iso();
     // Reset Fail-Counter bei explizitem PW-Reset
     $u['failed_login_attempts'] = 0;

--- a/api/users/update.php
+++ b/api/users/update.php
@@ -13,9 +13,13 @@ $found = false;
 foreach ($users as &$u) {
   if ($u['id'] === $id) {
     $found = true;
-    foreach (['first_name','last_name','userid','email','role','locked', 'department'] as $k) {
+    foreach (['first_name','last_name','userid','email','role','locked', 'department', 'force_password_change'] as $k) {
       if (array_key_exists($k, $in)) {
         if ($k==='role' && !in_array($in[$k], ['user','admin'], true)) continue;
+        if ($k==='force_password_change') {
+          $u[$k] = (bool)$in[$k];
+          continue;
+        }
         $u[$k] = $in[$k];
       }
     }

--- a/app/AuthManager.js
+++ b/app/AuthManager.js
@@ -42,6 +42,11 @@ export const AuthManager = (function(){
       return;
     }
 
+    if (info?.user?.force_password_change) {
+      window.location.href = '/loptastic/pw.php';
+      return;
+    }
+
     /*// User ins Projektsettings spiegeln
     const project = StateManager.getCurrentProject();
     if (project) {

--- a/app/index.html
+++ b/app/index.html
@@ -215,6 +215,10 @@
                                             <a href="user_admin.php" class="btn btn-sm btn-primary" >Admin Menu</a>
                                         </div>
 
+                                        <a href="/loptastic/pw.php" class="btn btn-sm btn-outline-primary">
+                                            Passwort ändern
+                                        </a>
+
                                         <button id="logout-link" class="btn btn-sm btn-outline-secondary">
                                             <i class="bi bi-check"></i> Logout
                                         </button>

--- a/assets/change-password.js
+++ b/assets/change-password.js
@@ -1,0 +1,76 @@
+(() => {
+  const form = document.getElementById('change-password-form');
+  const msg = document.getElementById('msg');
+  const hint = document.getElementById('hint');
+  const btn = document.getElementById('btn-change');
+  let csrf = '';
+
+  function setMsg(text, isError = true) {
+    msg.textContent = text || '';
+    msg.style.color = isError ? '#b91c1c' : '#15803d';
+  }
+
+  async function loadMe() {
+    const res = await fetch('/loptastic/api/auth/me.php', { credentials: 'include' });
+    const data = await res.json();
+    if (!data.ok || !data?.data?.authenticated) {
+      location.href = '/loptastic/login.php';
+      return;
+    }
+
+    csrf = data.data.csrf || '';
+    if (data?.data?.user?.force_password_change) {
+      hint.textContent = 'Du musst dein vom Admin gesetztes Initial-Passwort jetzt ändern.';
+      return;
+    }
+    hint.textContent = 'Hier kannst du dein Passwort freiwillig ändern.';
+    hint.style.color = '#475569';
+  }
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    setMsg('');
+
+    const oldPassword = document.getElementById('old_password').value;
+    const newPassword = document.getElementById('new_password').value;
+    const newPassword2 = document.getElementById('new_password2').value;
+
+    if (!oldPassword || !newPassword) {
+      setMsg('Bitte alle Felder ausfüllen.');
+      return;
+    }
+    if (newPassword !== newPassword2) {
+      setMsg('Die neuen Passwörter stimmen nicht überein.');
+      return;
+    }
+
+    btn.disabled = true;
+    try {
+      const res = await fetch('/loptastic/api/auth/change_password.php', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrf,
+        },
+        body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
+        credentials: 'include'
+      });
+
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || 'Passwort konnte nicht geändert werden');
+
+      setMsg('Passwort erfolgreich geändert. Du wirst zur App weitergeleitet.', false);
+      setTimeout(() => {
+        location.href = '/loptastic/';
+      }, 1000);
+    } catch (err) {
+      setMsg(err.message || 'Fehler beim Ändern des Passworts');
+    } finally {
+      btn.disabled = false;
+    }
+  });
+
+  loadMe().catch(() => {
+    location.href = '/loptastic/login.php';
+  });
+})();

--- a/assets/login.js
+++ b/assets/login.js
@@ -21,6 +21,10 @@
       });
       const data = await res.json();
       if (!data.ok) throw new Error(data.error || 'Login fehlgeschlagen');
+      if (data?.data?.user?.force_password_change) {
+        location.href = '/loptastic/pw.php';
+        return;
+      }
       location.href = '/loptastic/';
     } catch (err) {
       setMsg(err.message);

--- a/assets/user-admin.js
+++ b/assets/user-admin.js
@@ -43,6 +43,10 @@ const status = u.pending
   ? '<span class="badge locked">wartet auf Freigabe</span>' 
   : (u.locked ? '<span class="badge locked">gesperrt</span>' : 'aktiv');
 
+const passwordStatus = u.force_password_change
+  ? '<span class="badge locked">Passwortwechsel erforderlich</span>'
+  : '<span class="badge user">ok</span>';
+
 tr.innerHTML = `
   <td>${u.first_name} ${u.last_name}</td>
   <td>${u.userid}<br><small>${u.email}</small></td>
@@ -51,12 +55,14 @@ tr.innerHTML = `
   <td>${u.department ?? '—'}</td>
   <td>${u.last_login_at ?? '—'}</td>
   <td>${u.created_at ?? '—'}</td>
+  <td>${passwordStatus}</td>
   <td>
     ${u.pending 
       ? `<button onclick="approveUser('${u.id}')">Freigeben</button>`
       : `<button onclick="toggleLock('${u.id}', ${!u.locked})">Sperren/Entsperren</button>`
     }
     <button onclick="resetPass('${u.id}')">Passwort setzen</button>
+    <button onclick="forcePwChange('${u.id}')">Reset erzwingen</button>
     <button onclick="delUser('${u.id}')">Löschen</button>
   </td>`;
     tb.appendChild(tr);
@@ -115,6 +121,19 @@ async function resetPass(id) {
   const j = await r.json();
   if (!j.ok) return alert(j.error||'Fehler');
   alert('Passwort aktualisiert');
+  loadUsers();
+}
+
+async function forcePwChange(id) {
+  const r = await fetch('/loptastic/api/users/update.php', {
+    method:'POST', credentials:'include',
+    headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
+    body: JSON.stringify({id, force_password_change: true})
+  });
+  const j = await r.json();
+  if (!j.ok) return alert(j.error||'Fehler');
+  alert('Passwort-Reset beim nächsten Login erzwungen');
+  loadUsers();
 }
 
 async function delUser(id) {

--- a/data/users.template.json
+++ b/data/users.template.json
@@ -10,6 +10,7 @@
         "created_at": "2025-09-20T00:00:00Z",
         "updated_at": "2025-09-20T00:00:00Z",
         "last_login_at": "2025-10-10T12:36:41+02:00",
+        "force_password_change": false,
         "failed_login_attempts": 0,
         "locked_until": null,
         "password_hash": "$2y$10$89cENx\/soSa5sfM7bSH25utwkvvuIAbfcNZyDOwWWFBBeLb9kmmh6"

--- a/pw.php
+++ b/pw.php
@@ -1,1 +1,57 @@
-<?php echo password_hash('123456', PASSWORD_DEFAULT);
+<?php
+/**
+ * LopTastic – Community Edition
+ * Projektmanagement-Tool
+ */
+declare(strict_types=1);
+ini_set('session.use_strict_mode', '1');
+session_start([
+  'cookie_httponly' => true,
+  'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+  'cookie_samesite' => 'Lax',
+  'use_strict_mode' => true,
+]);
+if (!isset($_SESSION['uid'])) {
+  header('Location: /loptastic/login.php');
+  exit;
+}
+?><!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LopTastic – Passwort ändern</title>
+  <link rel="stylesheet" href="/loptastic/assets/login.css">
+</head>
+<body class="splash-bg">
+  <div class="login-wrapper">
+    <div class="login-card" style="max-width: 900px;">
+      <div class="login-left" style="width:100%;">
+        <h2>Passwort ändern</h2>
+        <p id="hint" class="msg" style="display:block;color:#9f1239;"></p>
+
+        <form id="change-password-form">
+          <div class="form-group">
+            <label for="old_password">Aktuelles Passwort</label>
+            <input type="password" id="old_password" autocomplete="current-password" required>
+          </div>
+          <div class="form-group">
+            <label for="new_password">Neues Passwort</label>
+            <input type="password" id="new_password" autocomplete="new-password" required>
+          </div>
+          <div class="form-group">
+            <label for="new_password2">Neues Passwort wiederholen</label>
+            <input type="password" id="new_password2" autocomplete="new-password" required>
+          </div>
+
+          <button type="submit" id="btn-change">Speichern</button>
+          <p id="msg" class="msg"></p>
+          <p style="margin-top: 20px;"><a href="/loptastic/">Zurück zur App</a></p>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="/loptastic/assets/change-password.js" defer></script>
+</body>
+</html>

--- a/user_admin.php
+++ b/user_admin.php
@@ -96,6 +96,7 @@ if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; 
           <th>Abteilung</th>
           <th>Letzter Login</th>
           <th>Erstellt</th>
+          <th>Passwortstatus</th>
           <th>Aktionen</th>
         </tr>
       </thead>


### PR DESCRIPTION
### Motivation
- Neue Benutzer oder vom Admin gesetzte Passwörter müssen vom jeweiligen User beim ersten Login ersetzt werden, um Sicherheit zu erhöhen.
- Es soll einen sichtbaren Link in der Sidebar unter `Benutzer` geben, damit Users ihr Passwort selbst ändern können.
- Admins müssen in der Userverwaltung ein erzwingbares Passwort-Reset für einen User setzen können.

### Description
- Introduce `force_password_change` flag across user/auth code paths and data template by updating `api/users/create.php`, `api/users/set_password.php`, `api/users/update.php`, `api/users/list.php` and `data/users.template.json` so new/admin-reset users are marked for password change and the flag can be toggled via update API.
- Expose the flag in auth responses by adding `force_password_change` to `api/auth/login.php` and `api/auth/me.php`, and clear it on successful self-service change in `api/auth/change_password.php`.
- Add front-end flow and UI: new `pw.php` page and `assets/change-password.js` to let users change passwords, redirect logic in `assets/login.js` and `app/AuthManager.js` to force navigation to `/pw.php` when required, and a sidebar link under `Benutzer` in `app/index.html`.
- Admin UX improvements: `assets/user-admin.js` and `user_admin.php` now show password-status in the admin table and provide a "Reset erzwingen" action which sets the flag via `api/users/update.php`.

### Testing
- Linted modified PHP files with `php -l` for each changed PHP file and received no syntax errors.
- Ran an automated Playwright check that started a local PHP server, performed login/navigation and produced screenshots of the sidebar and admin UI (artifacts saved), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addec9f5a08328acbe6c0f3cf04c37)