### PR TITLE
Make base URL/path dynamic to allow multiple localhost instances

### DIFF
--- a/admin_settings.php
+++ b/admin_settings.php
@@ -1,21 +1,22 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/lib_app_base.php';
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
-'cookie_path'     => '/loptastic/',
+'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
-if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; }
+if (!isset($_SESSION['uid'])) { header('Location: ' . loptastic_url('login.php')); exit; }
 ?><!doctype html>
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <title>LopTastic – Einstellungen</title>
-  <link rel="stylesheet" href="/loptastic/assets/admin.css">
-  <link rel="icon" type="image/x-icon" href="/loptastic/app/images/favicon.ico">
+  <link rel="stylesheet" href="assets/admin.css">
+  <link rel="icon" type="image/x-icon" href="app/images/favicon.ico">
   <style>
     .container{max-width:95%;margin:40px auto;background:#fff;border-radius:16px;padding:24px;color:#0f172a}
     .topbar{display:flex;justify-content:space-between;align-items:center;color:#fff;padding:16px}
@@ -39,13 +40,13 @@ if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; 
 <body class="splash-bg">
   <div class="topbar">
     <div><strong>loptastic</strong> – Einstellungen</div>
-    <div><a class="link" href="/loptastic/">Zurück zur App</a></div>
+    <div><a class="link" href="./">Zurück zur App</a></div>
   </div>
 
   <div class="container">
     <nav class="admin-nav" aria-label="Admin Navigation">
-      <a href="/loptastic/user_admin.php">Userverwaltung</a>
-      <a href="/loptastic/admin_settings.php" class="active">Einstellungen</a>
+      <a href="./user_admin.php">Userverwaltung</a>
+      <a href="./admin_settings.php" class="active">Einstellungen</a>
     </nav>
 
     <h1 style="margin-top:0">Systemeinstellungen</h1>
@@ -62,6 +63,6 @@ if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; 
     </div>
   </div>
 
-  <script src="/loptastic/assets/admin-settings.js" defer></script>
+  <script src="assets/admin-settings.js" defer></script>
 </body>
 </html>

--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -25,13 +25,14 @@
 
 // /loptastic/api/_bootstrap.php
 declare(strict_types=1);
+require_once __DIR__ . '/../lib_app_base.php';
 
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
-'cookie_path'     => '/loptastic/',
+'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
 
@@ -52,7 +53,7 @@ if (isset($_SESSION['LAST_ACTIVITY']) && (time() - $_SESSION['LAST_ACTIVITY'] > 
     'cookie_httponly' => true,
     'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
     'cookie_samesite' => 'Lax',
-    'cookie_path'     => '/loptastic/',
+    'cookie_path'     => loptastic_url('/'),
     'use_strict_mode' => true,
   ]);
 

--- a/app/AuthManager.js
+++ b/app/AuthManager.js
@@ -26,9 +26,13 @@
 // /loptastic/app/AuthManager.js
 export const AuthManager = (function(){
   let _me = null;
+  const appBasePath = window.location.pathname
+    .replace(/\/[^/]*$/, '')
+    .replace(/\/$/, '');
+  const appUrl = (path) => `${appBasePath}${path.startsWith('/') ? path : `/${path}`}`;
 
   async function me() {
-    const res = await fetch('/loptastic/api/auth/me.php', { credentials: 'include' });
+    const res = await fetch(appUrl('/api/auth/me.php'), { credentials: 'include' });
     const j = await res.json();
     if (!j.ok) throw new Error(j.error || 'Auth Fehler');
     _me = j.data;
@@ -38,12 +42,12 @@ export const AuthManager = (function(){
   async function ensureLoggedIn() {
     const info = await me();
     if (!info.authenticated) {
-      window.location.href = '/loptastic/login.php';
+      window.location.href = appUrl('/login.php');
       return;
     }
 
     if (info?.user?.force_password_change) {
-      window.location.href = '/loptastic/pw.php';
+      window.location.href = appUrl('/pw.php');
       return;
     }
 

--- a/app/app.js
+++ b/app/app.js
@@ -95,14 +95,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     
      // Logout-Handler
+    const appBasePath = window.location.pathname
+        .replace(/\/[^/]*$/, '')
+        .replace(/\/$/, '');
+    const appUrl = (path) => `${appBasePath}${path.startsWith('/') ? path : `/${path}`}`;
+
     const logoutEl = document.getElementById('logout-link');
     if (logoutEl) {
         logoutEl.addEventListener('click', async (e) => {
             e.preventDefault();
             try {
-                await fetch('/loptastic/api/auth/logout.php', { credentials: 'include' });
+                await fetch(appUrl('/api/auth/logout.php'), { credentials: 'include' });
             } finally {
-                location.href = '/loptastic/login.php';
+                location.href = appUrl('/login.php');
             }
         });
     }

--- a/app/index.html
+++ b/app/index.html
@@ -215,7 +215,7 @@
                                             <a href="user_admin.php" class="btn btn-sm btn-primary" >Admin Menu</a>
                                         </div>
 
-                                        <a href="/loptastic/pw.php" class="btn btn-sm btn-outline-primary">
+                                        <a href="pw.php" class="btn btn-sm btn-outline-primary">
                                             Passwort ändern
                                         </a>
 

--- a/assets/admin-settings.js
+++ b/assets/admin-settings.js
@@ -8,11 +8,11 @@ const sectionDescriptionEl = document.getElementById('section-description');
 const editorEl = document.getElementById('settings-json');
 
 async function loadMe() {
-  const r = await fetch('/loptastic/api/auth/me.php', { credentials: 'include' });
+  const r = await fetch('api/auth/me.php', { credentials: 'include' });
   const j = await r.json();
   if (!j.ok || !j.data?.authenticated || j.data?.user?.role !== 'admin') {
     alert('Adminrechte erforderlich');
-    location.href = '/loptastic/login.php';
+    location.href = 'login.php';
     return false;
   }
   csrfToken = j.data.csrf;
@@ -20,7 +20,7 @@ async function loadMe() {
 }
 
 async function loadSections() {
-  const r = await fetch('/loptastic/api/admin/settings/get.php', { credentials: 'include' });
+  const r = await fetch('api/admin/settings/get.php', { credentials: 'include' });
   const j = await r.json();
   if (!j.ok) {
     alert(j.error || 'Settings konnten nicht geladen werden');
@@ -57,7 +57,7 @@ function selectSection(key) {
 
 async function reloadActiveSection() {
   if (!activeSection) return;
-  const r = await fetch(`/loptastic/api/admin/settings/get.php?section=${encodeURIComponent(activeSection)}`, { credentials: 'include' });
+  const r = await fetch(`api/admin/settings/get.php?section=${encodeURIComponent(activeSection)}`, { credentials: 'include' });
   const j = await r.json();
   if (!j.ok) {
     alert(j.error || 'Bereich konnte nicht neu geladen werden');
@@ -82,7 +82,7 @@ async function saveActiveSection() {
     return;
   }
 
-  const r = await fetch('/loptastic/api/admin/settings/save.php', {
+  const r = await fetch('api/admin/settings/save.php', {
     method: 'POST',
     credentials: 'include',
     headers: {

--- a/assets/change-password.js
+++ b/assets/change-password.js
@@ -63,7 +63,7 @@
 
   async function loadPolicy() {
     try {
-      const res = await fetch('/loptastic/api/public/settings/password_policy.php', { cache: 'no-cache' });
+      const res = await fetch('api/public/settings/password_policy.php', { cache: 'no-cache' });
       const data = await res.json();
       if (data?.ok && data?.data?.password_policy) {
         policy = { ...policy, ...data.data.password_policy };
@@ -77,10 +77,10 @@
   }
 
   async function loadMe() {
-    const res = await fetch('/loptastic/api/auth/me.php', { credentials: 'include' });
+    const res = await fetch('api/auth/me.php', { credentials: 'include' });
     const data = await res.json();
     if (!data.ok || !data?.data?.authenticated) {
-      location.href = '/loptastic/login.php';
+      location.href = 'login.php';
       return;
     }
 
@@ -114,7 +114,7 @@
 
     btn.disabled = true;
     try {
-      const res = await fetch('/loptastic/api/auth/change_password.php', {
+      const res = await fetch('api/auth/change_password.php', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -129,7 +129,7 @@
 
       setMsg('Passwort erfolgreich geändert. Du wirst zur App weitergeleitet.', false);
       setTimeout(() => {
-        location.href = '/loptastic/';
+        location.href = './';
       }, 1000);
     } catch (err) {
       setMsg(err.message || 'Fehler beim Ändern des Passworts');
@@ -139,6 +139,6 @@
   });
 
   Promise.all([loadPolicy(), loadMe()]).catch(() => {
-    location.href = '/loptastic/login.php';
+    location.href = 'login.php';
   });
 })();

--- a/assets/login.js
+++ b/assets/login.js
@@ -13,7 +13,7 @@
     try {
       const login = document.getElementById('login').value.trim();
       const password = document.getElementById('password').value;
-      const res = await fetch('/loptastic/api/auth/login.php', {
+      const res = await fetch('api/auth/login.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({ login, password }),
@@ -22,10 +22,10 @@
       const data = await res.json();
       if (!data.ok) throw new Error(data.error || 'Login fehlgeschlagen');
       if (data?.data?.user?.force_password_change) {
-        location.href = '/loptastic/pw.php';
+        location.href = 'pw.php';
         return;
       }
-      location.href = '/loptastic/';
+      location.href = './';
     } catch (err) {
       setMsg(err.message);
     } finally {

--- a/assets/register.js
+++ b/assets/register.js
@@ -64,7 +64,7 @@ function isPasswordPolicySatisfied(password) {
 
 async function loadDepartmentsAndPolicy() {
   try {
-    const res = await fetch('/loptastic/api/public/settings/registration.php');
+    const res = await fetch('api/public/settings/registration.php');
     const payload = await res.json();
     const departments = payload?.data?.departments || [];
     const policy = payload?.data?.password_policy;
@@ -122,7 +122,7 @@ document.getElementById('register-form')?.addEventListener('submit', async (e) =
   }
 
   try {
-    const res = await fetch('/loptastic/api/auth/register.php', {
+    const res = await fetch('api/auth/register.php', {
       method:'POST',
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify(body)

--- a/assets/user-admin.js
+++ b/assets/user-admin.js
@@ -20,17 +20,17 @@ function val(id){
 function clearInputs(...ids){ ids.forEach(i=>{ const el = document.getElementById(i); if (el) el.value=''; }); }
 
 async function me() {
-  const r = await fetch('/loptastic/api/auth/me.php', {credentials:'include'});
+  const r = await fetch('api/auth/me.php', {credentials:'include'});
   const j = await r.json();
-  if (!j.ok) { alert(j.error||'Fehler'); location.href='/loptastic/login.php'; return; }
+  if (!j.ok) { alert(j.error||'Fehler'); location.href='login.php'; return; }
   CSRF = j.data.csrf;
   if (!j.data.authenticated || (j.data.user.role!=='admin')) {
-    alert('Adminrechte erforderlich'); location.href='/loptastic/'; return;
+    alert('Adminrechte erforderlich'); location.href='./'; return;
   }
 }
 
 async function loadUsers() {
-  const r = await fetch('/loptastic/api/users/list.php', {credentials:'include'});
+  const r = await fetch('api/users/list.php', {credentials:'include'});
   const j = await r.json();
   if (!j.ok) { alert(j.error||'Fehler'); return; }
 
@@ -69,7 +69,7 @@ tr.innerHTML = `
   });
 }
 async function approveUser(id) {
-  const r = await fetch('/loptastic/api/users/approve.php', {
+  const r = await fetch('api/users/approve.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify({id})
@@ -88,7 +88,7 @@ async function createUser() {
     password: val('password'),
     department: val('department')
   };
-  const r = await fetch('/loptastic/api/users/create.php', {
+  const r = await fetch('api/users/create.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify(body)
@@ -100,7 +100,7 @@ async function createUser() {
 }
 
 async function toggleLock(id, lock) {
-  const r = await fetch('/loptastic/api/users/update.php', {
+  const r = await fetch('api/users/update.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify({id, locked: !!lock})
@@ -113,7 +113,7 @@ async function toggleLock(id, lock) {
 async function resetPass(id) {
   const pw = prompt('Neues Passwort:');
   if (!pw) return;
-  const r = await fetch('/loptastic/api/users/set_password.php', {
+  const r = await fetch('api/users/set_password.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify({id, password: pw})
@@ -125,7 +125,7 @@ async function resetPass(id) {
 }
 
 async function forcePwChange(id) {
-  const r = await fetch('/loptastic/api/users/force_password_reset.php', {
+  const r = await fetch('api/users/force_password_reset.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify({id})
@@ -138,7 +138,7 @@ async function forcePwChange(id) {
 
 async function delUser(id) {
   if (!confirm('User wirklich löschen?')) return;
-  const r = await fetch('/loptastic/api/users/delete.php', {
+  const r = await fetch('api/users/delete.php', {
     method:'POST', credentials:'include',
     headers:{'Content-Type':'application/json','X-CSRF-Token':CSRF},
     body: JSON.stringify({id})
@@ -150,7 +150,7 @@ async function delUser(id) {
 
 async function loadDepartmentsSelect(selectId, currentValue="") {
   try {
-    const res = await fetch('/loptastic/api/public/settings/registration.php', {cache:"no-cache"});
+    const res = await fetch('api/public/settings/registration.php', {cache:"no-cache"});
     const payload = await res.json();
     const departments = payload?.data?.departments || [];
     const sel = document.getElementById(selectId);

--- a/index.php
+++ b/index.php
@@ -25,16 +25,17 @@
 
 // /loptastic/index.php
 declare(strict_types=1);
+require_once __DIR__ . '/lib_app_base.php';
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
-'cookie_path'     => '/loptastic/',
+'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
 if (!isset($_SESSION['uid'])) {
-  header('Location: /loptastic/login.php');
+  header('Location: ' . loptastic_url('login.php'));
   exit;
 }
 
@@ -57,12 +58,12 @@ if ($currentUser === null) {
   // der Client nicht in einen Redirect-Loop über AuthManager läuft.
   $_SESSION = [];
   session_destroy();
-  header('Location: /loptastic/login.php');
+  header('Location: ' . loptastic_url('login.php'));
   exit;
 }
 
 if (!empty($currentUser['force_password_change'])) {
-  header('Location: /loptastic/pw.php');
+  header('Location: ' . loptastic_url('pw.php'));
   exit;
 }
 readfile(__DIR__ . '/app/index.html');

--- a/lib_app_base.php
+++ b/lib_app_base.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+function loptastic_base_path(): string {
+  static $basePath = null;
+  if ($basePath !== null) {
+    return $basePath;
+  }
+
+  $scriptName = str_replace('\\', '/', $_SERVER['SCRIPT_NAME'] ?? '');
+  $dir = rtrim(dirname($scriptName), '/');
+  if ($dir === '.' || $dir === '/') {
+    $dir = '';
+  }
+
+  if (preg_match('#^(.*?)/api(?:/.*)?$#', $dir, $m)) {
+    $dir = $m[1];
+  }
+
+  $basePath = $dir;
+  return $basePath;
+}
+
+function loptastic_url(string $path = '/'): string {
+  $base = loptastic_base_path();
+
+  if ($path === '' || $path === '/') {
+    return ($base !== '' ? $base : '') . '/';
+  }
+
+  return ($base !== '' ? $base : '') . '/' . ltrim($path, '/');
+}

--- a/login.php
+++ b/login.php
@@ -23,14 +23,15 @@
  * - Externe Bibliotheken behalten ihre eigenen Lizenzen.
  */
 
-// /loptastic/login.php
+// ./login.php
 declare(strict_types=1);
+require_once __DIR__ . '/lib_app_base.php';
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
- 'cookie_path'     => '/loptastic/',
+ 'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
 if (isset($_SESSION['uid'])) {
@@ -50,7 +51,7 @@ if (isset($_SESSION['uid'])) {
   }
 
   if ($isValidSessionUser) {
-    header('Location: /loptastic/');
+    header('Location: ' . loptastic_url('/'));
     exit;
   }
 
@@ -66,7 +67,7 @@ if (isset($_SESSION['uid'])) {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LopTastic – Login</title>
-  <link rel="stylesheet" href="/loptastic/assets/login.css">
+  <link rel="stylesheet" href="assets/login.css">
 </head>
 <body class="splash-bg">
   <div class="login-wrapper">
@@ -84,7 +85,7 @@ if (isset($_SESSION['uid'])) {
             <input type="password" id="password" autocomplete="current-password" required>
           </div>
           <button type="submit" id="btn-login">Login</button>
-          <p style="margin-top: 50px;">Noch keinen Account? <a href="/loptastic/register.php">Jetzt Registrieren</a></p>
+          <p style="margin-top: 50px;">Noch keinen Account? <a href="register.php">Jetzt Registrieren</a></p>
           <p id="msg" class="msg"></p>
         </form>
         
@@ -101,7 +102,7 @@ if (isset($_SESSION['uid'])) {
   </div>
 
 
-  <script src="/loptastic/assets/login.js" defer></script>
+  <script src="assets/login.js" defer></script>
 </body>
 </html>
 

--- a/pw.php
+++ b/pw.php
@@ -4,16 +4,17 @@
  * Projektmanagement-Tool
  */
 declare(strict_types=1);
+require_once __DIR__ . '/lib_app_base.php';
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
- 'cookie_path'     => '/loptastic/',
+ 'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
 if (!isset($_SESSION['uid'])) {
-  header('Location: /loptastic/login.php');
+  header('Location: ' . loptastic_url('login.php'));
   exit;
 }
 ?><!doctype html>
@@ -22,7 +23,7 @@ if (!isset($_SESSION['uid'])) {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LopTastic – Passwort ändern</title>
-  <link rel="stylesheet" href="/loptastic/assets/login.css">
+  <link rel="stylesheet" href="assets/login.css">
   <style>
     .pw-rule { padding:4px 8px; border-radius:8px; background:#f8fafc; border:1px solid #e2e8f0; }
     .pw-rule.ok { background:#f0fdf4; border-color:#86efac; color:#166534; }
@@ -54,12 +55,12 @@ if (!isset($_SESSION['uid'])) {
 
           <button type="submit" id="btn-change">Speichern</button>
           <p id="msg" class="msg"></p>
-          <p style="margin-top: 20px;"><a href="/loptastic/">Zurück zur App</a></p>
+          <p style="margin-top: 20px;"><a href="./">Zurück zur App</a></p>
         </form>
       </div>
     </div>
   </div>
 
-  <script src="/loptastic/assets/change-password.js" defer></script>
+  <script src="assets/change-password.js" defer></script>
 </body>
 </html>

--- a/register.php
+++ b/register.php
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LopTastic – Registrierung</title>
-  <link rel="stylesheet" href="/loptastic/assets/login.css">
+  <link rel="stylesheet" href="assets/login.css">
   <style>
     .pw-rule { padding:4px 8px; border-radius:8px; background:#f8fafc; border:1px solid #e2e8f0; }
     .pw-rule.ok { background:#f0fdf4; border-color:#86efac; color:#166534; }
@@ -51,7 +51,7 @@
           <button type="submit" id="btn-register">Registrieren</button>
           <p id="msg" class="msg"></p>
           <p class="small" style="margin-top: 50px;">
-            Schon einen Account? <a href="/loptastic/login.php">besser zum Login</a>
+            Schon einen Account? <a href="./login.php">besser zum Login</a>
           </p>
         </form>
       </div>
@@ -65,6 +65,6 @@
       </div>
     </div>
   </div>
-  <script src="/loptastic/assets/register.js" defer></script>
+  <script src="./assets/register.js" defer></script>
 </body>
 </html>

--- a/user_admin.php
+++ b/user_admin.php
@@ -23,24 +23,25 @@
  * - Externe Bibliotheken behalten ihre eigenen Lizenzen.
  */
 
-// /loptastic/user-admin.php
+// ./user-admin.php
 declare(strict_types=1);
+require_once __DIR__ . '/lib_app_base.php';
 ini_set('session.use_strict_mode', '1');
 session_start([
   'cookie_httponly' => true,
   'cookie_secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
   'cookie_samesite' => 'Lax',
- 'cookie_path'     => '/loptastic/',
+ 'cookie_path'     => loptastic_url('/'),
   'use_strict_mode' => true,
 ]);
-if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; }
+if (!isset($_SESSION['uid'])) { header('Location: ' . loptastic_url('login.php')); exit; }
 ?><!doctype html>
 <html lang="de">
 <head>
   <meta charset="utf-8">
   <title>LopTastic – Userverwaltung</title>
-  <link rel="stylesheet" href="/loptastic/assets/admin.css">
-  <link rel="icon" type="image/x-icon" href="/loptastic/app/images/favicon.ico">
+  <link rel="stylesheet" href="assets/admin.css">
+  <link rel="icon" type="image/x-icon" href="app/images/favicon.ico">
   <style>
     .container{max-width:95%;margin:40px auto;background:#fff;border-radius:16px;padding:24px}
     table{width:100%;border-collapse:collapse;margin-top:16px; color: black}
@@ -62,12 +63,12 @@ if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; 
 <body class="splash-bg">
   <div class="topbar">
     <div><strong>loptastic</strong> – Userverwaltung</div>
-    <div><a class="link" href="/loptastic/">Zurück zur App</a></div>
+    <div><a class="link" href="./">Zurück zur App</a></div>
   </div>
   <div class="container">
     <nav style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px" aria-label="Admin Navigation">
-      <a style="padding:8px 12px;border-radius:8px;background:#0f172a;color:#fff;text-decoration:none;font-weight:600" href="/loptastic/user_admin.php">Userverwaltung</a>
-      <a style="padding:8px 12px;border-radius:8px;background:#e2e8f0;color:#0f172a;text-decoration:none;font-weight:600" href="/loptastic/admin_settings.php">Einstellungen</a>
+      <a style="padding:8px 12px;border-radius:8px;background:#0f172a;color:#fff;text-decoration:none;font-weight:600" href="./user_admin.php">Userverwaltung</a>
+      <a style="padding:8px 12px;border-radius:8px;background:#e2e8f0;color:#0f172a;text-decoration:none;font-weight:600" href="./admin_settings.php">Einstellungen</a>
     </nav>
     <div class="toolbar">
       <div class="row">
@@ -105,6 +106,6 @@ if (!isset($_SESSION['uid'])) { header('Location: /loptastic/login.php'); exit; 
       <tbody></tbody>
     </table>
   </div>
-  <script src="/loptastic/assets/user-admin.js" defer></script>
+  <script src="assets/user-admin.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The app used a hardcoded `/loptastic/` path for session cookie scope, redirects and API calls which prevents running multiple instances side-by-side under different subpaths (e.g. `/loptastic_AI`, `/loptastic_feature_1234`).
- Goal is to make the base path dynamic so one codebase can be served from arbitrary subpaths without breaking cookies, redirects or asset/API calls.

### Description
- Added a small PHP helper `lib_app_base.php` that exposes `loptastic_base_path()` and `loptastic_url()` to detect the current install subpath from `$_SERVER['SCRIPT_NAME']` and build URLs dynamically.
- Replaced hardcoded `/loptastic/` values in server entry points with the dynamic helper for `session` `cookie_path` and redirects in files like `index.php`, `login.php`, `pw.php`, `user_admin.php`, `admin_settings.php` and `api/_bootstrap.php`.
- Converted server-side HTML asset and navigation links to relative paths (e.g. `assets/...`, `./login.php`) so pages work when mounted under a different subpath.
- Updated frontend scripts to use subpath-safe API/redirect calls by switching to relative `api/...` fetches and adding runtime base-path helpers in `app/AuthManager.js` and `app/app.js` (logout flow), and adjusted `assets/*.js` accordingly.